### PR TITLE
Make wifi element clickable to toggle wifi on/off

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ After cloning the project, simply activate all three "simple-bar" widgets in Üb
 - `simple-bar-spaces-jsx`
 - `simple-bar-data-jsx`
 
+### Clickable elements
+
+The wifi element in `simple-bar-data-jsx` is clickable. If you have an interaction shortcut enabled (`Übersicht > Preferences`), you can click the wifi element to toggle wifi on or off.
+
 ## Customization
 
 If you want to customize the colors or fonts used you can simply edit the `simple-bar > lib > styles > Theme.js` and put your settings in it.

--- a/lib/components/Wifi.jsx
+++ b/lib/components/Wifi.jsx
@@ -1,16 +1,29 @@
 import { Wifi, WifiOff } from './Icons.jsx';
+import { run } from "uebersicht";
+
+const wifi_on = () => {
+  run(`osascript -e 'tell app "System Events" to display notification "enabling wifi." with title "simple-bar"'`);
+  run(`networksetup -setairportpower en0 on`);
+};
+
+const wifi_off = () => {
+  run(`osascript -e 'tell app "System Events" to display notification "disabling wifi." with title "simple-bar"'`);
+  run(`networksetup -setairportpower en0 off`);
+};
 
 const render = ({ output }) => {
   if (!output) return null;
   const { status, ssid } = output;
   const isActive = status === 'active';
 
-  const classes = isActive ? 'wifi' : 'wifi wifi--inactive';
+  const classes = 'clickable' + isActive ? 'wifi' : 'wifi wifi--inactive';
 
   const Icon = isActive ? Wifi : WifiOff;
 
+  const wifi_exec = isActive ? wifi_off : wifi_on;
+
   return (
-    <div className={classes}>
+    <div className={classes} onClick={wifi_exec}>
       <Icon className="wifi__icon" />
       {ssid && ssid}
     </div>


### PR DESCRIPTION
Straightforward addition that makes wifi clickable. If clicked, it turns wifi on/off (depending on current state) and sends a notification to the user informing of the action.

Added a note about it in the readme also.