### PR TITLE
Add Spotify element

### DIFF
--- a/data.jsx
+++ b/data.jsx
@@ -3,10 +3,11 @@ import DateDisplay from './lib/components/Date.jsx'
 import Battery from './lib/components/Battery.jsx'
 import Sound from './lib/components/Sound.jsx'
 import Wifi from './lib/components/Wifi.jsx'
+import Spotify from './lib/components/Spotify.jsx'
 
 import { parseJson } from './lib/utils.js'
 
-import { DateStyles, TimeStyles, BatteryStyles, WifiStyles, SoundStyles } from './lib/styles/Styles.js'
+import { DateStyles, TimeStyles, BatteryStyles, WifiStyles, SoundStyles, SpotifyStyles } from './lib/styles/Styles.js'
 import { Theme } from './lib/styles/Theme.js'
 
 const refreshFrequency = 10000
@@ -34,6 +35,7 @@ const className = /* css */ `
   ${BatteryStyles}
   ${WifiStyles}
   ${SoundStyles}
+  ${SpotifyStyles}
 `
 
 const command = 'bash simple-bar/lib/scripts/get_data.sh'
@@ -42,9 +44,10 @@ const render = ({ output, error }) => {
   if (!output || error) return <div className="simple-bar__error">Something went wrong...</div>
   const data = parseJson(output)
   if (!data) return <div className="simple-bar__error">JSON error...</div>
-  const { battery, wifi, sound } = data
+  const { battery, wifi, sound, spotify } = data
   return (
     <div className="simple-bar__data">
+      <Spotify output={spotify} />
       <Battery output={battery} />
       <Sound output={sound} />
       <Wifi output={wifi} />

--- a/lib/components/Icons.jsx
+++ b/lib/components/Icons.jsx
@@ -52,6 +52,22 @@ export const DateIcon = (props) => (
   </Icon>
 )
 
+export const PlayingIcon = (props) => (
+  <Icon {...props}>
+    <path d="M3 22v-20l18 10-18 10z" />
+  </Icon>
+)
+
+export const PausedIcon = (props) => (
+  <Icon {...props}>
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M4.16667 2H8.83333C9.47767 2 10 2.50368 10 3.125V20.875C10 21.4963 9.47767 22 8.83333 22H4.16667C3.52233 22 3 21.4963 3 20.875V3.125C3 2.50368 3.52233 2 4.16667 2ZM15.1667 2H19.8333C20.4777 2 21 2.50368 21 3.125V20.875C21 21.4963 20.4777 22 19.8333 22H15.1667C14.5223 22 14 21.4963 14 20.875V3.125C14 2.50368 14.5223 2 15.1667 2Z"
+    />
+  </Icon>
+)
+
 export const CalendarIcon = (props) => (
   <Icon {...props}>
     <path d="M20 20h-4v-4h4v4zm-6-10h-4v4h4v-4zm6 0h-4v4h4v-4zm-12 6h-4v4h4v-4zm6 0h-4v4h4v-4zm-6-6h-4v4h4v-4zm16-8v22h-24v-22h3v1c0 1.103.897 2 2 2s2-.897 2-2v-1h10v1c0 1.103.897 2 2 2s2-.897 2-2v-1h3zm-2 6h-20v14h20v-14zm-2-7c0-.552-.447-1-1-1s-1 .448-1 1v2c0 .552.447 1 1 1s1-.448 1-1v-2zm-14 2c0 .552-.447 1-1 1s-1-.448-1-1v-2c0-.552.447-1 1-1s1 .448 1 1v2z" />

--- a/lib/components/Spotify.jsx
+++ b/lib/components/Spotify.jsx
@@ -3,8 +3,8 @@ import { run } from 'uebersicht'
 import { PlayingIcon, PausedIcon } from './Icons.jsx'
 import { refreshData, clickEffect, truncate } from '../utils'
 
-const togglePlay = (isActive) => {
-  if (isActive) {
+const togglePlay = (isPaused) => {
+  if (isPaused) {
     run(`osascript -e 'tell application "Spotify" to play'`).then(refreshData)
   } else {
     run(`osascript -e 'tell application "Spotify" to pause'`).then(refreshData)

--- a/lib/components/Spotify.jsx
+++ b/lib/components/Spotify.jsx
@@ -1,0 +1,35 @@
+import { run } from 'uebersicht'
+
+import { PlayingIcon, PausedIcon } from './Icons.jsx'
+import { refreshData, clickEffect, truncate } from '../utils'
+
+const togglePlay = (isActive) => {
+  if (isActive) {
+    run(`osascript -e 'tell application "Spotify" to play'`).then(refreshData)
+  } else {
+    run(`osascript -e 'tell application "Spotify" to pause'`).then(refreshData)
+  }
+}
+
+const Spotify = ({ output }) => {
+  if (!output) return null
+  const { playerState, trackName, artistName, spotifyIsRunning } = output
+  if (spotifyIsRunning === 'false') return null
+
+  const isPlaying = playerState === 'playing'
+  const Icon = isPlaying ? PlayingIcon : PausedIcon
+
+  const clicked = (e) => {
+    clickEffect(e)
+    togglePlay(!isPlaying)
+  }
+
+  return (
+    <div className="spotify" onClick={clicked}>
+      <Icon className="spotify__icon" />
+      {truncate(trackName, 16)} - {truncate(artistName, 16)}
+    </div>
+  )
+}
+
+export default Spotify

--- a/lib/components/Wifi.jsx
+++ b/lib/components/Wifi.jsx
@@ -1,9 +1,6 @@
 import { run } from 'uebersicht'
 import { WifiIcon, WifiOffIcon } from './Icons.jsx'
-import { classnames, clickEffect } from '../utils.js'
-
-const refreshData = () =>
-  run(`osascript -e 'tell application id "tracesOf.Uebersicht" to refresh widget id "simple-bar-data-jsx"'`)
+import { classnames, clickEffect, refreshData } from '../utils.js'
 
 const toggleWifi = (isActive) => {
   if (isActive) {

--- a/lib/scripts/get_data.sh
+++ b/lib/scripts/get_data.sh
@@ -17,6 +17,14 @@ WIFI_SSID=$(networksetup -getairportnetwork en0 | cut -c 24-)
 VOLUME=$(osascript -e 'set ovol to output volume of (get volume settings)')
 MUTED=$(osascript -e 'set ovol to output muted of (get volume settings)')
 
+SPOTIFY_IS_RUNNING=$(osascript -e 'tell application "System Events" to (name of processes) contains "Spotify"')
+
+if [ "$SPOTIFY_IS_RUNNING" == true ]; then
+  SPOTIFY_PLAYER_STATE=$(osascript -e 'tell application "Spotify" to player state as string')
+  SPOTIFY_TRACK_NAME=$(osascript -e 'tell application "Spotify" to name of current track as string')
+  SPOTIFY_ARTIST_NAME=$(osascript -e 'tell application "Spotify" to artist of current track as string')
+fi
+
 echo $(cat <<-EOF
   {
     "battery": {
@@ -31,6 +39,12 @@ echo $(cat <<-EOF
     "sound": {
       "volume": "$VOLUME",
       "muted": "$MUTED"
+    },
+    "spotify": {
+      "spotifyIsRunning": "$SPOTIFY_IS_RUNNING",
+      "playerState": "$SPOTIFY_PLAYER_STATE",
+      "trackName": "$SPOTIFY_TRACK_NAME",
+      "artistName": "$SPOTIFY_ARTIST_NAME"
     }
   }
 EOF

--- a/lib/styles/Styles.js
+++ b/lib/styles/Styles.js
@@ -14,7 +14,7 @@ export const SpacesStyles = /* css */ `
 @keyframes space-appearance {
   0% {
     opacity: 0;
-    transform: scale(0);  
+    transform: scale(0);
   }
   100% {
     opacity: 1;
@@ -171,7 +171,7 @@ export const SpacesStyles = /* css */ `
 }
 .space-options__option:not(:last-child):hover {
   background-color: ${Theme.lightGrey};
-} 
+}
 .space-options__option:last-child:hover {
   opacity: 1;
 }
@@ -365,5 +365,32 @@ export const TimeStyles = /* css */ `
   height: 14px;
   margin-right: 7px;
   fill: ${Theme.main};
+}
+`
+export const SpotifyStyles = /* css */ `
+.spotify {
+  display: flex;
+  align-items: center;
+  padding: 3px 7px;
+  background-color: ${Theme.green};
+  border-radius: 2px;
+  box-shadow: ${Theme.lightShadow};
+}
+@media (prefers-color-scheme: light) {
+  .spotify {
+    background-color: white;
+  }
+}
+.spotify__icon {
+  width: 14px;
+  height: 14px;
+  margin-right: 7px;
+  fill: ${Theme.main};
+}
+.spotify:hover {
+  opacity: 0.7;
+}
+.spotify:active {
+  transform: scale(0.9);
 }
 `

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,5 @@
+import { run } from 'uebersicht'
+
 export const parseJson = (json) => {
   try {
     return JSON.parse(json)
@@ -78,4 +80,14 @@ export const clickEffect = (e) => {
     )
   }
   setTimeout(() => cursor && body.removeChild(cursor), DURATION)
+}
+
+export const refreshData = () =>
+  run(`osascript -e 'tell application id "tracesOf.Uebersicht" to refresh widget id "simple-bar-data-jsx"'`)
+
+export const truncate = (str, maxLength) => {
+  if (str.length > maxLength) {
+    return str.substring(0, maxLength) + '...'
+  }
+  return str
 }


### PR DESCRIPTION
Added Spotify element:
- Displays current track and artist names
- Icon changes based on currently playing/paused
- Clicking the element pauses and unpauses the current track
- Hides when Spotify is closed

Playing:
<img width="700" alt="Screenshot 2020-09-12 at 21 40 36" src="https://user-images.githubusercontent.com/8133259/93004656-e4967880-f540-11ea-98c7-d6cfb564672a.png">


Paused:
<img width="700" alt="Screenshot 2020-09-12 at 21 40 42" src="https://user-images.githubusercontent.com/8133259/93004658-e95b2c80-f540-11ea-842f-c031a731d888.png">

Spotify closed:
<img width="700" alt="Screenshot 2020-09-12 at 21 57 57" src="https://user-images.githubusercontent.com/8133259/93004870-245e5f80-f543-11ea-9e14-0d85afda6d4e.png">

Not sure whether this element should be enabled by default?