### PR TITLE
Refresh Spaces When Clicking on a New Space

### DIFF
--- a/lib/yabai.js
+++ b/lib/yabai.js
@@ -8,6 +8,7 @@ const refreshSpaces = () => {
 export const goToSpace = async (index, focusedSpace) => {
   if (index === focusedSpace) return
   await run(`/usr/local/bin/yabai -m space --focus ${index}`)
+  refreshSpaces()
 }
 
 export const createSpace = (displayId) => {


### PR DESCRIPTION
Putting in this PR because I noticed that when I click a new space, it's properly highlighted, but the old space is never un-highlighted. I added this refresh in after a goToSpace command, which seems to have fixed the issue.