### PR TITLE
Set process.jsx refreshFrequency to true

### DIFF
--- a/process.jsx
+++ b/process.jsx
@@ -5,7 +5,7 @@ import { parseJson, getTheme } from './lib/utils.js'
 
 import { styles } from './lib/styles/Styles.js'
 
-const refreshFrequency = false
+const refreshFrequency = true
 
 const theme = getTheme()
 const Styles = styles[theme]


### PR DESCRIPTION
If this is set to false the process simply remains frozen at whatever it was when the bar was last refreshed...

Feel free to change the frequency to whatever you think is best, but having it set to false isn't the default behaviour you want, right?