### PR TITLE
Add show specter setting

### DIFF
--- a/lib/components/Settings.jsx
+++ b/lib/components/Settings.jsx
@@ -129,6 +129,20 @@ const Settings = () => {
               )
             })}
           </div>
+          <div className="settings__inner-title">Spotify</div>
+          <div className="settings__items">
+            {Object.keys(settings.spotifyWidgetOptions).map((key) => {
+              const setting = settings.spotifyWidgetOptions[key]
+              const onSpotifyWidgetOptionsChange = (e) =>
+                setSettings('spotifyWidgetOptions', key, e.target.checked, 'data')
+              return (
+                <div key={key} className="settings__item">
+                  <input id={key} type="checkbox" defaultChecked={setting} onChange={onSpotifyWidgetOptionsChange} />
+                  <label htmlFor={key}>{settingsLabels[key]}</label>
+                </div>
+              )
+            })}
+          </div>
         </div>
       </div>
     </div>

--- a/lib/components/Spotify.jsx
+++ b/lib/components/Spotify.jsx
@@ -16,9 +16,10 @@ const togglePlay = (isPaused) => {
 
 const Spotify = ({ output }) => {
   const settings = getSettings()
-  const { spotifyWidget } = settings.widgets
+  const { widgets: spotifyWidget, spotifyWidgetOptions } = settings
   if (!spotifyWidget || !output) return null
   const { playerState, trackName, artistName, spotifyIsRunning } = output
+  const { showSpecter } = spotifyWidgetOptions
   if (spotifyIsRunning === 'false' || trackName === '' || artistName === '') return null
 
   const isPlaying = playerState === 'playing'
@@ -53,7 +54,7 @@ const Spotify = ({ output }) => {
   return (
     <div className={classes} onClick={onClick} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
       <Icon className="spotify__icon" />
-      {isPlaying && <Specter />}
+      {showSpecter && isPlaying && <Specter />}
       <div className="spotify__inner">
         <div className="spotify__slider">
           {trackName} - {artistName}

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -14,7 +14,8 @@ export const settingsLabels = {
   shortDateFormat: 'Short format',
   floatingBar: 'Floating bar',
   noBarBg: 'No bar background',
-  noColorInData: 'No colors in data'
+  noColorInData: 'No colors in data',
+  showSpecter: 'Show specter'
 }
 
 // theme: 'auto' || 'dark' || 'light'
@@ -41,6 +42,9 @@ export const defaultSettings = {
   },
   dateWidgetOptions: {
     shortDateFormat: true
+  },
+  spotifyWidgetOptions: {
+    showSpecter: false
   }
 }
 


### PR DESCRIPTION
Added a setting to show/hide the specter in the Spotify component

![Screenshot 2020-10-08 at 09 31 37](https://user-images.githubusercontent.com/8133259/95434438-28667d00-0949-11eb-9d26-53d907561fe8.png)

By the way, I added this because I noticed that the `WindowServer` process idles at a constant 30% CPU when the specter was displaying, disabling the specter returns it to normal levels

Defaulted this to false because of performance impact, not sure if others have seen this problem?