### PR TITLE
Combine battery icons

### DIFF
--- a/lib/components/Battery.jsx
+++ b/lib/components/Battery.jsx
@@ -27,8 +27,14 @@ const Battery = ({ output }) => {
 
   return (
     <div className={classes}>
-      {isCharging && <ChargingIcon className="battery__charging-icon" />}
       <div className="battery__icon">
+        {isCharging && (
+          <div className="battery__charging-icon">
+            <ChargingIcon className="battery__charging-icon__outline-left" />
+            <ChargingIcon className="battery__charging-icon__fill" />
+            <ChargingIcon className="battery__charging-icon__outline-right" />
+          </div>
+        )}
         <div className="battery__icon-filler" style={{ transform: transformValue }} />
       </div>
       {percentage}%

--- a/lib/styles/DarkTheme.js
+++ b/lib/styles/DarkTheme.js
@@ -449,10 +449,31 @@ export const BatteryStyles = /* css */ `
   box-shadow: ${Theme.lightShadow};
 }
 .battery__charging-icon {
+  position: absolute;
+  left: 3px;
+}
+.battery__charging-icon__fill {
+  position: absolute;
   width: 10px;
   height: 10px;
-  margin: 2px 2px 0 0;
   fill: ${Theme.main};
+  z-index: 3;
+}
+.battery__charging-icon__outline-left {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  fill: ${Theme.magenta};
+  left: -1px;
+  z-index: 2;
+}
+.battery__charging-icon__outline-right {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  fill: ${Theme.magenta};
+  left: 1px;
+  z-index: 2;
 }
 .battery__icon {
   position: relative;
@@ -483,6 +504,7 @@ export const BatteryStyles = /* css */ `
   transform: scaleX(0);
   transform-origin: left center;
   transition: transform 160ms ${Theme.easing};
+  z-index: 1;
 }
 .battery--low .battery__icon-filler {
   background-color: ${Theme.red};
@@ -675,7 +697,7 @@ export const BrowserTrackStyles = /* css */ `
   width: 10px;
   height: 10px;
   stroke: ${Theme.green};
-  stroke-width: 3px; 
+  stroke-width: 3px;
 }
 .browser-track__inner {
   max-width: 140px;

--- a/lib/styles/DarkTheme.js
+++ b/lib/styles/DarkTheme.js
@@ -449,7 +449,7 @@ export const BatteryStyles = /* css */ `
   box-shadow: ${Theme.lightShadow};
 }
 .battery__charging-icon {
-  position: absolute;
+  position: relative;
   left: 3px;
 }
 .battery__charging-icon__fill {

--- a/lib/styles/LightTheme.js
+++ b/lib/styles/LightTheme.js
@@ -397,7 +397,7 @@ export const BatteryStyles = /* css */ `
   box-shadow: ${Theme.lightShadow};
 }
 .battery__charging-icon {
-  position: absolute;
+  position: relative;
   left: 3px;
 }
 .battery__charging-icon__fill {

--- a/lib/styles/LightTheme.js
+++ b/lib/styles/LightTheme.js
@@ -397,10 +397,31 @@ export const BatteryStyles = /* css */ `
   box-shadow: ${Theme.lightShadow};
 }
 .battery__charging-icon {
+  position: absolute;
+  left: 3px;
+}
+.battery__charging-icon__fill {
+  position: absolute;
   width: 10px;
   height: 10px;
-  margin: 2px 2px 0 0;
   fill: ${Theme.main};
+  z-index: 3;
+}
+.battery__charging-icon__outline-left {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  fill: #fff;
+  left: -1px;
+  z-index: 2;
+}
+.battery__charging-icon__outline-right {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  fill: #fff;
+  left: 1px;
+  z-index: 2;
 }
 .battery__icon {
   position: relative;
@@ -431,6 +452,7 @@ export const BatteryStyles = /* css */ `
   transform: scaleX(0);
   transform-origin: left center;
   transition: transform 160ms ${Theme.easing};
+  z-index: 1;
 }
 .battery--low .battery__icon-filler {
   background-color: ${Theme.red};
@@ -615,7 +637,7 @@ export const BrowserTrackStyles = /* css */ `
   width: 10px;
   height: 10px;
   stroke: white;
-  stroke-width: 3px; 
+  stroke-width: 3px;
 }
 .browser-track__inner {
   max-width: 140px;


### PR DESCRIPTION
Combined battery and charging icons into one to reduce the width of the battery widget when charging

###### Separate (current implementation)
<img width="570" alt="Screenshot 2020-10-08 at 11 45 09 (2)" src="https://user-images.githubusercontent.com/8133259/95448851-dda23080-095b-11eb-9ef0-c1ac2a4addad.png">

###### Combined Dark Charging
<img width="570" alt="Screenshot 2020-10-08 at 11 11 17 (2)" src="https://user-images.githubusercontent.com/8133259/95446614-6c14b300-0958-11eb-9c7e-a8f49958d2ef.png">

###### Combined Dark Discharging
<img width="570" alt="Screenshot 2020-10-08 at 11 11 47 (2)" src="https://user-images.githubusercontent.com/8133259/95446620-6fa83a00-0958-11eb-81a3-782182ad2756.png">

###### Combined Light Charging
<img width="570" alt="Screenshot 2020-10-08 at 11 17 24 (2)" src="https://user-images.githubusercontent.com/8133259/95446629-73d45780-0958-11eb-9b53-58cb53a2ce78.png">

###### Combined Light Discharging
<img width="570" alt="Screenshot 2020-10-08 at 11 11 58 (2)" src="https://user-images.githubusercontent.com/8133259/95446636-7636b180-0958-11eb-93c3-a75fc6892dc7.png">
