### PR TITLE
Fixed create space command not working

### DIFF
--- a/lib/yabai.js
+++ b/lib/yabai.js
@@ -9,8 +9,8 @@ const { yabaiPath } = settings.global
 export const goToSpace = (index) => run(`${yabaiPath} -m space --focus ${index}`)
 
 export const createSpace = (displayId) => {
-  run(`${yabaiPath} -m display --focus ${displayId}`).then(() => {
-    run('${yabaiPath} -m space --create').then(refreshSpaces)
+  run(`${yabaiPath} -m display --focus ${displayId}`).then(async () => {
+    run(`${yabaiPath} -m space --create`).then(refreshSpaces)
   })
 }
 


### PR DESCRIPTION
Caused by using quotes instead of backticks. Also used async as with destroy space