### PR TITLE
fix: unique key warning

### DIFF
--- a/lib/components/Settings.jsx
+++ b/lib/components/Settings.jsx
@@ -101,7 +101,7 @@ const Settings = () => {
                     }
                   }
                   return (
-                    <>
+                    <div key={subKey}>
                       {title && <div className="settings__item-title">{title}</div>}
                       <div key={subKey} className={classes} onChange={type === 'radio' ? onChange : undefined}>
                         <Item
@@ -114,7 +114,7 @@ const Settings = () => {
                           onChange={onChange}
                         />
                       </div>
-                    </>
+                    </div>
                   )
                 })}
                 {infos && infos.length && (

--- a/lib/components/Settings.jsx
+++ b/lib/components/Settings.jsx
@@ -4,7 +4,7 @@ import { CloseIcon } from './Icons.jsx'
 
 import { getSettings, setSettings, settingsData } from '../settings.js'
 
-const { useState, useEffect, useCallback } = React
+const { useState, useEffect, useCallback, Fragment } = React
 
 const Item = ({ code, defaultValue, label, type, options, placeholder, onChange }) => {
   if (type === 'radio') {
@@ -101,7 +101,7 @@ const Settings = () => {
                     }
                   }
                   return (
-                    <div key={subKey}>
+                    <Fragment key={subKey}>
                       {title && <div className="settings__item-title">{title}</div>}
                       <div key={subKey} className={classes} onChange={type === 'radio' ? onChange : undefined}>
                         <Item
@@ -114,7 +114,7 @@ const Settings = () => {
                           onChange={onChange}
                         />
                       </div>
-                    </div>
+                    </Fragment>
                   )
                 })}
                 {infos && infos.length && (


### PR DESCRIPTION
There might be a better way to solve this but this seems to remove the warning about not returning a list with unique keys.

![image](https://user-images.githubusercontent.com/14061533/102586663-dbeaab00-410a-11eb-8da5-7b0327818b45.png)
