### PR TITLE
Fix return for contains in get-data

### DIFF
--- a/lib/scripts/get_data.sh
+++ b/lib/scripts/get_data.sh
@@ -5,9 +5,9 @@ VPN_CONNECTION_NAME="$4"
 
 contains() {
   if printf '%s\n' "$1" | grep -Fqe "$2"; then
-    return 1
-  else
     return 0
+  else
+    return 1
   fi
 }
 


### PR DESCRIPTION
Hi there, this is pretty self explanatory. 
I encountered this while investigating an issue with browser tracking. 
While using browser tracking ( with a lot of tabs ), the process timed out even though I've removed the widget in settings - it seemed to call all items in the script regardless of the configuration. 