### PR TITLE
hotfix: handle unknown weather response from wttr.in

### DIFF
--- a/lib/scripts/get_data.sh
+++ b/lib/scripts/get_data.sh
@@ -15,6 +15,9 @@ WEATHER="{}"
 if contains "$ACTIVE_WIDGETS" "weatherWidget"; then
   if [ "$WEATHER_LOCATION" != "" ]; then
     WEATHER=$(curl -s "wttr.in/$WEATHER_LOCATION?format=j1" 2>/dev/null || echo "{}")
+    if contains "$WEATHER" "Unknown"; then 
+      WEATHER="{}"
+    fi
   fi
 fi
 


### PR DESCRIPTION
wttr.in may return an unknown response, which causes a JSON parse error.
If I get time to work on this a bit later next week, I think it'll be appropriate to add a function that checks what fields in the returned JSON are malformed instead of failing fast when JSON.parse errors out.