### PR TITLE
Don't open Google Chrome when it is not running

### DIFF
--- a/lib/scripts/browser_audio.applescript
+++ b/lib/scripts/browser_audio.applescript
@@ -12,7 +12,7 @@ to replace_chars(this_text, search_string, replacement_string)
 end replace_chars
 
 try
-  do shell script "osascript -e 'exists application \"Google Chrome\"'"
+  do shell script "osascript -e 'id of application \"Google Chrome\"'"
   if application "Google Chrome" is running then
     tell application "Google Chrome"
       set window_list to every window


### PR DESCRIPTION
Using 'exists application' will always start the application if it is not running. By just getting the application id we will counter this behaviour.