### PR TITLE
"Process" widget: Don't show the title if it's meaningless (same as app title, or empty)

### DIFF
--- a/lib/components/process/process.jsx
+++ b/lib/components/process/process.jsx
@@ -11,7 +11,7 @@ const Process = ({ output: apps }) => {
     const { app, title } = currentApp
     return (
       <div className="process">
-        {app} / {title}
+        {app == title ? app : `${app} / ${title}`}
       </div>
     )
   }

--- a/lib/components/process/process.jsx
+++ b/lib/components/process/process.jsx
@@ -11,7 +11,7 @@ const Process = ({ output: apps }) => {
     const { app, title } = currentApp
     return (
       <div className="process">
-        {app == title ? app : `${app} / ${title}`}
+        {app == title || title == '' ? app : `${app} / ${title}`}
       </div>
     )
   }

--- a/lib/components/process/window.jsx
+++ b/lib/components/process/window.jsx
@@ -45,7 +45,7 @@ const Window = ({ app }) => {
       <Icon className="process__icon" />
       <span className="process__inner">
         <span className="process__name">
-          {name == title ? name : `${name} / ${title}`}
+          {name == title || title == '' ? name : `${name} / ${title}`}
         </span>
       </span>
     </button>

--- a/lib/components/process/window.jsx
+++ b/lib/components/process/window.jsx
@@ -45,7 +45,7 @@ const Window = ({ app }) => {
       <Icon className="process__icon" />
       <span className="process__inner">
         <span className="process__name">
-          {name} / {title}
+          {name == title ? name : `${name} / ${title}`}
         </span>
       </span>
     </button>

--- a/lib/styles/components/process.js
+++ b/lib/styles/components/process.js
@@ -1,6 +1,6 @@
 export const processStyles = /* css */ `
 .process:not(.process--all-windows) {
-  min-width: 60px;
+  min-width: 48px;
   min-height: 12px;
   max-width: 20%;
   display: block;


### PR DESCRIPTION
Some windows don't need to show a particularly meaningful title, so they display the application name instead.

These windows are shown in simple-bar as **"WhatsApp / WhatsApp"**, or **"Telegram / Telegram"**.

This PR simply shows the application name only (e.g. **"WhatsApp"** or **"Telegram"**) in such cases.

This PR also does that if the title is empty (which happens for some app popups).

_(The `min-width` property of `.process:not(.process--all-windows)` has been slightly decreased in order to allow 8-chars process names to be displayed without having an odd gap on the right of the process name. For some reason the text isn't centered when the `min-width` takes effect.)_