### PR TITLE
Fix the weird background color for battery when caffeinate is enabled and the forecolor for sound widget

### DIFF
--- a/lib/styles/components/data/battery.js
+++ b/lib/styles/components/data/battery.js
@@ -9,7 +9,7 @@ export const batteryStyles = /* css */ `
   background-color: var(--white);
 }
 .simple-bar--no-color-in-data .battery--caffeinate {
-  background-color: var(--white);
+  fill: currentColor;
 }
 .battery__charging-icon {
   position: relative;
@@ -104,8 +104,7 @@ export const batteryStyles = /* css */ `
   background-color: var(--red);
 }
 .battery__caffeinate-icon {
-  position: absolute;
-  top: calc(50% - 6px);
+  position: relative;
   right: 1px;
   width: 20px;
   height: 20px;

--- a/lib/styles/components/data/sound.js
+++ b/lib/styles/components/data/sound.js
@@ -57,7 +57,7 @@ export const soundStyles = /* css */ `
   display: flex;
   align-items: center;
   margin-right: 4px;
-  color: var(--background);
+  color: var(--foreground);
   overflow: hidden;
 }
 .sound__display:active {


### PR DESCRIPTION
Fix issue https://github.com/Jean-Tinland/simple-bar/issues/172. See the screenshots below
* With no-color-in-data checked:
<img width="140" alt="image" src="https://user-images.githubusercontent.com/11582667/127578163-db6996b2-4480-43e1-ae97-c6140ff64df7.png">

* With no-color-in-data unchecked:
<img width="140" alt="image" src="https://user-images.githubusercontent.com/11582667/127578217-ee655e3f-9215-4d7b-bdb6-ed4837bb9db5.png">

Fix issue https://github.com/Jean-Tinland/simple-bar/issues/174
<img width="72" alt="image" src="https://user-images.githubusercontent.com/11582667/127578266-2f09e92c-3af2-4b53-88d4-42a6621058e6.png">
