### PR TITLE
Add Icon for WezTerm

### DIFF
--- a/lib/app-icons.js
+++ b/lib/app-icons.js
@@ -193,6 +193,7 @@ export const appIcons = {
   Joplin: JoplinIcon,
   Notability: NotabilityIcon,
   Skim: PDFIcon,
+  WezTerm: TerminalIcon,
 
   // German app names
   Nachrichten: MessagesIcon,


### PR DESCRIPTION
Gave [WezTerm](https://github.com/wez/wezterm) the "TerminalIcon"