### PR TITLE
Sticky window workaround + new settings for spaces display

### DIFF
--- a/lib/components/process/process.jsx
+++ b/lib/components/process/process.jsx
@@ -12,21 +12,21 @@ export const Component = ({ displayIndex, spaces, visibleSpaces, windows }) => {
   const { exclusionsAsRegex } = spacesDisplay
   const exclusions = exclusionsAsRegex ? spacesDisplay.exclusions : spacesDisplay.exclusions.split(', ')
   const titleExclusions = exclusionsAsRegex ? spacesDisplay.titleExclusions : spacesDisplay.titleExclusions.split(', ')
+  const currentSpace = spaces.filter(({ visible, display }) => visible && display === displayIndex)[0]
+  const {stickyWindows, nonStickyWindows} = Utils.stickyWindowWorkaround(windows, false, displayIndex, currentSpace.index, exclusions, titleExclusions, exclusionsAsRegex)
+
 
   return (
     <div className="process">
       <div className="process__container">
-        {process.showCurrentSpaceMode &&
-          spaces
-            .filter(({ display, index }) => visibleSpaces.includes(index) && display === displayIndex)
-            .map(({ index, type }) => (
-              <div key={index} className="process__layout">
-                {type}
+        {process.showCurrentSpaceMode && (
+              <div key={currentSpace.index} className="process__layout">
+                {currentSpace.type}
               </div>
-            ))}
-        {windows
-          .filter((app) => Utils.filterApps(app, exclusions, titleExclusions, exclusionsAsRegex))
-          .filter(({ display, space }) => visibleSpaces.includes(space) && display === displayIndex)
+          )}
+        {(stickyWindows.concat(nonStickyWindows))
+          // .filter((app) => Utils.filterApps(app, exclusions, titleExclusions, exclusionsAsRegex))
+          // .filter(({ display, space }) => visibleSpaces.includes(space) && display === displayIndex)
           .sort((a, b) => a.id > b.id)
           .map((window, i) => (
             <Window key={i} displayIndex={displayIndex} window={window} />

--- a/lib/components/spaces/space.jsx
+++ b/lib/components/spaces/space.jsx
@@ -16,7 +16,7 @@ const Space = ({ space, display, windows, displayIndex, SIPDisabled, lastOfSpace
   const [spaceLabel, setSpaceLabel] = Uebersicht.React.useState(label?.length ? label : index)
 
   const { spacesDisplay } = settings
-  const { displayAllSpacesOnAllScreens, exclusionsAsRegex } = spacesDisplay
+  const { displayAllSpacesOnAllScreens, exclusionsAsRegex, displayStickyWindowsSeparately, hideDuplicateAppsInSpaces } = spacesDisplay
   if (!displayAllSpacesOnAllScreens && display !== space.display) return null
 
   const exclusions = exclusionsAsRegex ? spacesDisplay.exclusions : spacesDisplay.exclusions.split(', ')
@@ -51,11 +51,10 @@ const Space = ({ space, display, windows, displayIndex, SIPDisabled, lastOfSpace
     Yabai.renameSpace(index, newLabel)
   }
 
-  const apps = windows.filter(
-    (app) => app.space === index && Utils.filterApps(app, exclusions, titleExclusions, exclusionsAsRegex)
-  )
+  const {nonStickyWindows: apps, stickyWindows} = Utils.stickyWindowWorkaround(windows, hideDuplicateAppsInSpaces, display, index, exclusions, titleExclusions, exclusionsAsRegex)
+  const allApps = apps.concat(stickyWindows);
 
-  if (!focused && !visible && apps.length === 0 && spacesDisplay.hideEmptySpaces) return null
+  if (!focused && !visible && allApps.length === 0 && spacesDisplay.hideEmptySpaces) return null
 
   const classes = Utils.classnames(`space space--${type}`, {
     'space--focused': focused === 1,
@@ -63,7 +62,7 @@ const Space = ({ space, display, windows, displayIndex, SIPDisabled, lastOfSpace
     'space--fullscreen': fullscreen === 1,
     'space--hovered': hovered,
     'space--no-delay': noDelay,
-    'space--empty': apps.length === 0,
+    'space--empty': allApps.length === 0,
     'space--editable': editable
   })
 
@@ -83,7 +82,7 @@ const Space = ({ space, display, windows, displayIndex, SIPDisabled, lastOfSpace
             style={{ width: `${labelSize}ch` }}
             readOnly={!editable}
           />
-          <OpenedApps type={type} apps={apps} />
+          <OpenedApps type={type} apps={displayStickyWindowsSeparately ? apps : allApps} />
         </button>
         {!spacesDisplay.hideSpacesOptions && SIPDisabled && (
           <SpaceOptions index={index} setHovered={setHovered} displayIndex={displayIndex} />

--- a/lib/components/spaces/spaces.jsx
+++ b/lib/components/spaces/spaces.jsx
@@ -1,14 +1,15 @@
 import Space from './space.jsx'
+import Stickies from './stickies.jsx'
 import * as Icons from '../icons.jsx'
 import * as Utils from '../../utils'
 import * as Yabai from '../../yabai'
-
+import * as Settings from '../../settings'
 export { spacesStyles as styles } from '../../styles/components/spaces/spaces'
 
 export const Component = ({ output, SIP, displayIndex }) => {
   if (!output) return <div className="spaces-display spaces-display--empty" />
   const { spaces, windows } = output
-
+  const { displayStickyWindowsSeparately } = Settings.get().spacesDisplay
   const displays = [...new Set(spaces.map((space) => space.display))]
   const SIPDisabled = SIP !== 'System Integrity Protection status: enabled.'
   return displays.map((display, i) => {
@@ -19,6 +20,12 @@ export const Component = ({ output, SIP, displayIndex }) => {
     }
     return (
       <div key={i} className="spaces">
+      { displayStickyWindowsSeparately && (
+        <Stickies
+          display={display}
+          windows={windows}
+        />
+      )}
         {spaces.map((space, i) => {
           const { label, index } = space
           const lastOfSpace = i !== 0 && space.display !== spaces[i - 1].display

--- a/lib/components/spaces/stickies.jsx
+++ b/lib/components/spaces/stickies.jsx
@@ -1,0 +1,29 @@
+import * as Uebersicht from 'uebersicht'
+import OpenedApps from './opened-apps.jsx'
+import * as Utils from '../../utils'
+import * as Settings from '../../settings'
+
+
+const Stickies = ({ display, windows }) => {
+  const { spacesDisplay } = Settings.get()
+  const { exclusionsAsRegex, hideDuplicateAppsInSpaces } = spacesDisplay
+  const exclusions = exclusionsAsRegex ? spacesDisplay.exclusions : spacesDisplay.exclusions.split(', ')
+  const titleExclusions = exclusionsAsRegex ? spacesDisplay.titleExclusions : spacesDisplay.titleExclusions.split(', ')
+  
+  const {stickyWindows: apps} = Utils.stickyWindowWorkaround(windows, hideDuplicateAppsInSpaces, display, undefined, exclusions, titleExclusions, exclusionsAsRegex)
+
+  if (apps.length === 0) return null
+
+  return (
+    <Uebersicht.React.Fragment>
+      <div className="stickies">
+      <button className="stickies_inner">
+          <OpenedApps type="stickies" apps={apps} />
+      </button>
+      </div>
+      <div className="spaces__separator" />
+    </Uebersicht.React.Fragment>
+  )
+}
+
+export default Stickies

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -91,7 +91,8 @@ export const data = {
   displayAllSpacesOnAllScreens: { label: 'Display all spaces on all screens', type: 'checkbox', fullWidth: true },
   hideEmptySpaces: { label: 'Hide empty spaces', type: 'checkbox' },
   hideSpacesOptions: { label: 'Hide space options', type: 'checkbox' },
-
+  hideDuplicateAppsInSpaces: { label: 'Hide duplicate app icons in same space (useful in combination with process widget)', type: 'checkbox', fullWidth: true },
+  displayStickyWindowsSeparately: { label: 'Display sticky windows separately', type: 'checkbox', fullWidth: true },
   widgets: { label: 'Widgets' },
   processWidget: { label: 'Process name', type: 'checkbox' },
   zoomWidget: { label: 'Zoom', type: 'checkbox' },
@@ -200,6 +201,8 @@ export const defaultSettings = {
     titleExclusions: '',
     exclusionsAsRegex: false,
     displayAllSpacesOnAllScreens: false,
+    hideDuplicateAppsInSpaces: false,
+    displayStickyWindowsSeparately: false,
     hideEmptySpaces: false,
     hideSpacesOptions: false
   },

--- a/lib/styles/components/process.js
+++ b/lib/styles/components/process.js
@@ -30,12 +30,14 @@ export const processStyles = /* css */ `
 .process__layout {
   display: flex;
   align-items: center;
-  margin-right: 10px;
+  margin: var(--item-outer-margin);
+  padding: var(--item-inner-margin);
   font-size: 10px;
   font-style: italic;
   text-transform: uppercase;
   opacity: 0.5;
 }
+
 .process__window {
   display: flex;
   align-items: center;

--- a/lib/styles/components/spaces/space.js
+++ b/lib/styles/components/spaces/space.js
@@ -1,17 +1,19 @@
 export const spaceStyles = /* css */ `
-.space {
+.space, .stickies {
   position: relative;
   display: flex;
   align-items: center;
   animation: space-appearance 320ms var(--transition-easing);
 }
+
 @keyframes space-appearance {
   0% {
     opacity: 0;
   }
 }
 .space__inner,
-.spaces__add {
+.spaces__add,
+.stickies_inner {
   height: 100%;
   display: flex;
   align-items: center;
@@ -30,6 +32,15 @@ export const spaceStyles = /* css */ `
   transition: color 160ms var(--transition-easing), background-color 160ms var(--transition-easing), 
     border 160ms var(--transition-easing), box-shadow 160ms var(--transition-easing);
   z-index: 0;
+}
+
+.stickies_inner {
+  background-color: var(--background);
+  box-shadow: none;
+}
+
+.stickies_inner .space__icon:first-child {
+  margin: 0;
 }
 .space:first-of-type .space__inner {
   margin-left: 0;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -157,7 +157,7 @@ export const compareObjects = (obj1, obj2) => {
 }
 
 export const filterApps = (app, exclusions, titleExclusions, exclusionsAsRegex) => {
-  const { 'native-fullscreen': fullscreen, app: appName, title: appTitle } = app
+  const { 'native-fullscreen': fullscreen, sticky, app: appName, title: appTitle } = app
   const isAppNameExcluded = exclusionsAsRegex
     ? exclusions.length !== 0 && new RegExp(exclusions).test(appName)
     : exclusions.includes(appName)
@@ -165,6 +165,18 @@ export const filterApps = (app, exclusions, titleExclusions, exclusionsAsRegex) 
     ? titleExclusions.length !== 0 && new RegExp(titleExclusions).test(appTitle)
     : titleExclusions.includes(appTitle)
   return fullscreen === 1 || (!isAppNameExcluded && !appTitle.length) || (!isAppNameExcluded && !isAppTitleExcluded)
+}
+
+export const stickyWindowWorkaround = (windows, uniqueApps, currentDisplay, currentSpace, exclusions, titleExclusions, exclusionsAsRegex) => {
+  const stickySet = new Set();
+  const stickyWindows = windows.filter(
+    (app) => app.sticky === 1 && app.display === currentDisplay && filterApps(app, exclusions, titleExclusions, exclusionsAsRegex) && !stickySet.has(uniqueApps? app.app : app.id) && stickySet.add(uniqueApps ? app.app : app.id)
+  )
+  const nonStickySet = new Set();
+  const nonStickyWindows = windows.filter(
+    (app) => app.sticky === 0 && app.space === currentSpace && filterApps(app, exclusions, titleExclusions, exclusionsAsRegex) && !nonStickySet.has(uniqueApps? app.app : app.id) && nonStickySet.add(uniqueApps ? app.app : app.id)
+  )
+  return {nonStickyWindows, stickyWindows};
 }
 
 export const refreshSpaces = () =>


### PR DESCRIPTION
I use sticky windows for all kinds of popups and preferences (and also some video players).
Yabai has a bug when it comes to querying those where sticky windows show multiple times in a random space instead of once in each spaces.

Since I don't know C I unfortunately can't fix that directly.
However, in this PR I implemented a workaround for this in simple-bar. Now sticky windows app-icons show up in all spaces of a given display like they should.

At the same time, I also implemented two additional options for the space display for myself which I think might prove useful for others:
  1. **Hide duplicate app icons in same spaces**  
  This option is useful when you are dealing with lots of windows from the same application (like I do for my terminal application kitty). Using the process widget at the same time you probably do not lose any valuable information and it makes for a more condensed, tidier view of the spaces.  
  I think other might appreciate it as well so I would like to share it.
  2. **Show sticky windows separately**  
  This is an alternative workaround for sticky windows. Some people might like this, depending on the yabai workflow and how you use sticky windows.
  _Example:_ 
![Pasted image 20210810203316](https://user-images.githubusercontent.com/46481738/128921412-cd1bb484-8adf-416e-8fa4-f9f3c87f03ee.png) 
In this example the three Desktop & Screen Saver preference windows are set to sticky and appear separately before all spaces.

Please tell me your opinion about those features and if I should change anything to get this PR accepted.
And thanks indeed for this marvellous utility (and the clean code)! :)

