### PR TITLE
Improve sort order of windows in opened-windows and process widgets

### DIFF
--- a/lib/components/process/process.jsx
+++ b/lib/components/process/process.jsx
@@ -33,11 +33,9 @@ export const Component = ({ displayIndex, spaces, visibleSpaces, windows }) => {
             {currentSpace.type}
           </div>
         )}
-        {apps
-          .sort((a, b) => a.id > b.id)
-          .map((window, i) => (
-            <Window key={i} displayIndex={displayIndex} window={window} />
-          ))}
+        {Utils.sortWindows(apps).map((window, i) => (
+          <Window key={i} window={window}/>
+        ))}
       </div>
     </div>
   )

--- a/lib/components/spaces/opened-apps.jsx
+++ b/lib/components/spaces/opened-apps.jsx
@@ -3,10 +3,9 @@ import * as Utils from '../../utils'
 
 const OpenedApps = ({ type, apps }) => {
   if (apps.length === 0) return null
-  return apps
-    .sort((a, b) => (type === 'stack' ? a['stack-index'] > b['stack-index'] : a.id > b.id))
+  return Utils.sortWindows(apps)
     .map((app, i) => {
-      const { minimized, focused, app: name, 'zoom-parent': zoomParent, 'zoom-fullscreen': zoomFullscreen } = app
+      const { minimized, sticky, focused, app: name, 'zoom-parent': zoomParent, 'zoom-fullscreen': zoomFullscreen } = app
       if (minimized === 1) return null
 
       const Icon = AppIcons.apps[name] || AppIcons.apps['Default']

--- a/lib/components/spaces/stickies.jsx
+++ b/lib/components/spaces/stickies.jsx
@@ -19,7 +19,7 @@ const Stickies = ({ display, windows }) => {
     exclusionsAsRegex
   )
 
-  if (!apps?.length) return null
+  if (!apps.filter(app => app.minimized === 0)?.length) return null
 
   return (
     <Uebersicht.React.Fragment>

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -179,7 +179,7 @@ export const stickyWindowWorkaround = (
   const stickySet = new Set()
   const stickyWindows = windows.filter(
     (app) =>
-      app.sticky === 1 &&
+      (app.sticky === 1 && app['native-fullscreen'] === 0) &&
       app.display === currentDisplay &&
       filterApps(app, exclusions, titleExclusions, exclusionsAsRegex) &&
       !stickySet.has(uniqueApps ? app.app : app.id) &&
@@ -188,7 +188,7 @@ export const stickyWindowWorkaround = (
   const nonStickySet = new Set()
   const nonStickyWindows = windows.filter(
     (app) =>
-      app.sticky === 0 &&
+      (app.sticky === 0 || app['native-fullscreen'] === 1) &&
       app.space === currentSpace &&
       filterApps(app, exclusions, titleExclusions, exclusionsAsRegex) &&
       !nonStickySet.has(uniqueApps ? app.app : app.id) &&
@@ -196,6 +196,14 @@ export const stickyWindowWorkaround = (
   )
   return { nonStickyWindows, stickyWindows }
 }
+
+export const sortWindows = (windows) =>
+  windows.sort((a, b) => {
+    if (a.frame.x !== b.frame.x) return a.frame.x > b.frame.x
+    if (a.frame.y !== b.frame.y) return a.frame.y > b.frame.y
+    if (a['stack-index'] !== b['stack-index']) return a['stack-index'] > b['stack-index']
+    return a.id > b.id
+  })
 
 export const refreshSpaces = () =>
   Uebersicht.run(


### PR DESCRIPTION
Currently, they are sorted by window.id which is stable but a bit random.
Inspired by one of the great macros from dominiklohmann over at the yabai repository, I introduce a well-defined sort order by window position and stack index.
This works like a charm together with the aforementioned macro to cycle through all non-minimized windows in the current space:
```bash
  yabai -m query --windows --space  \
  | jq -re "map(select(.minimized != 1)) | sort_by(.display, .frame.x, .frame.y, .\"stack-index\", .id) | reverse | nth(index(map(select(.focused == 1))) - 1).id" \
  | xargs -I{} yabai -m window --focus {} || yabai -m window --focus first
```

Also improved the way the stickies widget behaves when all sticky windows in a display are minimized.