### PR TITLE
more rounded nord buttons

### DIFF
--- a/lib/styles/themes/nord.js
+++ b/lib/styles/themes/nord.js
@@ -19,7 +19,7 @@ export const theme = {
   barHeight: '28px',
   barRadius: '16px',
   barInnerMargin: '3px',
-  itemRadius: '8px',
+  itemRadius: '14px',
   itemInnerMargin: '3px 9px',
   itemOuterMargin: '0 0 0 5px',
   hoverRing: '0 0 0 2px rgba(255, 255, 255, 0.75)',


### PR DESCRIPTION
This is a super minor 'fix': it makes buttons in the nord theme rounder, more in line with how nord buttons are often styled (see e.g. https://github.com/shaunsingh/nord.nvim). Up to you if you want to merge :)