### PR TITLE
Adding Tokyo Night theme

### DIFF
--- a/lib/styles/themes.js
+++ b/lib/styles/themes.js
@@ -17,6 +17,7 @@ import * as Sylens from './themes/sylens'
 import * as SpaceDuck from './themes/spaceduck'
 import * as MidsummerNightDark from './themes/midsummer-night-dark'
 import * as Catppuccin from './themes/catppuccin'
+import * as TokyoNight from './themes/tokyo-night'
 
 export const collection = {
   NightShiftDark: NightShiftDark.theme,
@@ -37,5 +38,6 @@ export const collection = {
   Sylens: Sylens.theme,
   SpaceDuck: SpaceDuck.theme,
   MidsummerNightDark: MidsummerNightDark.theme,
-  Catppuccin: Catppuccin.theme
+  Catppuccin: Catppuccin.theme,
+  TokyoNight: TokyoNight.theme
 }

--- a/lib/styles/themes/tokyo-night.js
+++ b/lib/styles/themes/tokyo-night.js
@@ -1,0 +1,33 @@
+export const theme = {
+  name: 'Tokyo Night',
+  kind: 'dark',
+  main: '#15161E',
+  mainAlt: '#302D41',
+  minor: '#15161E',
+  red: '#F7768E',
+  green: '#9ECE6A',
+  yellow: '#E0AF68',
+  orange: '#F8BD96',
+  blue: '#7AA2F7',
+  magenta: '#BB9AF7',
+  cyan: '#7DCFFF',
+  black: '#15161E',
+  white: '#A9B1D6',
+  foreground: '#A9B1D6',
+  transparentDark: 'rgba(0, 0, 0, 0.05)',
+  defaultFont: 'JetBrains Mono, monospace',
+  barHeight: '34px',
+  compactBarHeight: '28px',
+  barRadius: '9px',
+  barInnerMargin: '0px',
+  itemRadius: '5px',
+  itemInnerMargin: '0px 9px',
+  itemOuterMargin: '0 0 0 4px',
+  hoverRing: '0 0 0 2px rgba(255, 255, 255, 0.75)',
+  focusRing: '0 0 0 2px rgb(255, 255, 255)',
+  lightShadow: '0 5px 10px rgba(0, 0, 0, 0.24)',
+  transitionEasing: 'cubic-bezier(0.4, 0, 0.2, 1)',
+  clickEffect: 'rgba(255, 255, 255, 0.3)'
+}
+
+


### PR DESCRIPTION
Similarly to [a previous PR for Catppuccin theme](https://github.com/Jean-Tinland/simple-bar/pull/276), I thought it would be great to have the [TokyoNight](https://github.com/folke/tokyonight.nvim) theme as well.

I just copy pasted the Catppuccin theme and changed colors (except for the orange one, it's stays the same)

Previews :
![Screenshot 2022-05-26 at 10 42 54](https://user-images.githubusercontent.com/9380317/170511986-ac97f3ae-988c-4b4d-af18-80463205ab64.png)
![Screenshot 2022-05-26 at 10 43 30](https://user-images.githubusercontent.com/9380317/170512041-4bc89b88-49cb-4c55-90a7-28f80a76a23d.png)

