### PR TITLE
fix background issue with data widget

### DIFF
--- a/lib/styles/components/data/data-widget.js
+++ b/lib/styles/components/data/data-widget.js
@@ -19,6 +19,12 @@ export const dataWidgetStyles = /* css */ `
   box-shadow: var(--light-shadow);
   transition: all 160ms var(--transition-easing);
 }
+.simple-bar--no-bar-background .simple-bar__data {
+  padding: 4px 5px 4px 0;
+  background-color: var(--background);
+  box-shadow: var(--light-shadow);
+  border-radius: var(--bar-radius);
+}
 .simple-bar--no-color-in-data .data-widget {
   color: var(--foreground);
   background-color: var(--minor);


### PR DESCRIPTION
As detailed in #290, recent updates broke the background setting for data widgets, causing them to have no background when `No Bar Background` was set.

Previously the `No Bar Background` only removed background from places where no widgets were present, but the recent changes remove the background from the cluster of data widgets as well. Since the behavior of the spaces cluster remained unchanged, it leads me to believe that the behavior for data cluster is unintentional. 

This PR aims to restore the (assumed) intended behavior that was present before df70c4c44c262ca45bb883d3506730f0a1167bc6

The "new" styling for `.simple-bar--no-bar-background .simple-bar__data` is taken directly from `simple-bar--no-bar-background.simple-bar--data` present in the old (pre df70c4c44c262ca45bb883d3506730f0a1167bc6) `lib/styles/core/base.js`

The choice to put the styling in `lib/styles/components/data/data-widget.js` instead of any other place was made to mirror a similar setting for spaces widget present in `lib/styles/components/spaces/spaces.js`. Please let me know if the styling should be moved elsewhere

Any and all feedback is welcomed! I hope this can resolve the issue for other users as well!