### PR TITLE
Create pywal-from-desktop.sh

### DIFF
--- a/lib/styles/pywal/pywal-from-desktop.sh
+++ b/lib/styles/pywal/pywal-from-desktop.sh
@@ -1,0 +1,9 @@
+#! /usr/bin/env bash
+
+wal -n -s -i $(sqlite3 -readonly ~/Library/Application\ Support/Dock/desktoppicture.db 'SELECT * FROM data ORDER BY rowID DESC LIMIT 1;' | sed -e "s|~|$HOME|g")
+
+{
+  echo -n 'export const variables = '
+  cat "$HOME/.cache/wal/colors-speedcrunch.json"
+  echo ';'
+} > pywal.js


### PR DESCRIPTION
Convenient alternative to pywal-gen that automatically uses current desktop picture to create and set theme.