### PR TITLE
fix: space width when label

### DIFF
--- a/lib/components/spaces/space.jsx
+++ b/lib/components/spaces/space.jsx
@@ -146,7 +146,7 @@ const Space = ({
             className="space__label"
             onChange={onChange}
             value={spaceLabel}
-            style={{ width: `${labelSize}ch` }}
+            style={{ width: `${labelSize}em` }}
             readOnly={!editable}
           />
           <OpenedApps apps={displayStickyWindowsSeparately ? apps : allApps} />


### PR DESCRIPTION
before:
![Screenshot 2022-10-01 at 12 15 01](https://user-images.githubusercontent.com/52538691/193404720-3553ddf6-ff45-46a3-bdd9-ca3085cf7a5e.png)
after: 
![Screenshot 2022-10-01 at 12 15 12](https://user-images.githubusercontent.com/52538691/193404732-e50557b7-b0c3-4d04-8422-9fa30b9ed813.png)
