### PR TITLE
Fix no color in data setting

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -68,6 +68,7 @@ const render = ({ output, error }) => {
   const baseClasses = Utils.classnames("simple-bar", {
     "simple-bar--floating": settings.global.floatingBar,
     "simple-bar--no-bar-background": settings.global.noBarBg,
+    "simple-bar--no-color-in-data": settings.global.noColorInData,
     "simple-bar--on-bottom": settings.global.bottomBar,
     "simple-bar--inline-spaces-options": settings.global.inlineSpacesOptions,
     "simple-bar--spaces-background-color-as-foreground":


### PR DESCRIPTION
The setting was apparently not used anymore since https://github.com/Jean-Tinland/simple-bar/commit/df70c4c44c262ca45bb883d3506730f0a1167bc6. I've added it again.

This also fixes #323.
