### PR TITLE
Switch play/pause icons

### DIFF
--- a/lib/components/icons.jsx
+++ b/lib/components/icons.jsx
@@ -201,13 +201,13 @@ export const Date = (props) => (
   </Icon>
 );
 
-export const Playing = (props) => (
+export const Paused = (props) => (
   <Icon {...props}>
     <path d="M4.8 20V4l14.4 8-14.4 8z" />
   </Icon>
 );
 
-export const Paused = (props) => (
+export const Playing = (props) => (
   <Icon {...props}>
     <path d="M5.7 4h3.8c.5 0 .9.4.9.9v14.2c0 .5-.4.9-1 .9H5.8a1 1 0 01-.9-.9V4.9c0-.5.4-.9 1-.9zm8.8 0h3.8c.5 0 .9.4.9.9v14.2c0 .5-.4.9-1 .9h-3.7a1 1 0 01-.9-.9V4.9c0-.5.4-.9 1-.9z" />
   </Icon>


### PR DESCRIPTION
Issue #332 

The standard is that the paused icon is the right-pointing arrow, and the two vertical lines mean paused. This is not the case in this app.
I checked several apps (Spotify, VLC, macOS, chrome, youtube, and apple music) to confirm this. 

This change switches the names of the play and paused icons to reflect this.

**Before (Paused)**
<img width="201" alt="Screenshot 2023-03-27 at 10 51 24" src="https://user-images.githubusercontent.com/77908661/227812657-6150980d-efdc-4ff0-9ede-3a09f638455f.png">
**Before (Playing)**
<img width="207" alt="Screenshot 2023-03-27 at 10 52 21" src="https://user-images.githubusercontent.com/77908661/227812719-465effb8-452c-493d-a230-a6743f7e3fce.png">

**After (Paused)**
<img width="204" alt="Screenshot 2023-03-27 at 10 49 32" src="https://user-images.githubusercontent.com/77908661/227812561-0118cd51-5f11-4b1c-8efe-a1e2ce76cd86.png">
**After (Playing)**
<img width="201" alt="Screenshot 2023-03-27 at 10 50 25" src="https://user-images.githubusercontent.com/77908661/227812614-942f9a30-82e0-4098-a2fb-f22ac933231d.png">