### PR TITLE
showNetworkName toggle and small errors in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A more "lite" & less ressource greedy version is available [here](https://github
 - **Only with SIP disabled**: create new workspace on "+" click, move or destroy workspace on space hover
 
 (1) Settings can be opened by pressing `cmd + ,` after clicking on **simple-bar** widget. More details in [Settings](#settings) section.\
-(2) Press `cmd + t` while focusing **simple-bar** (a light blue border should be visible at this moment).\
+(2) Toggle dark/light mode by pressing `cmd + t` while focusing **simple-bar** (a light blue border should be visible at this moment).\
 (3) Currently supported: Google Chrome (YouTube & Spotify for browser), Brave (YouTube & Spotify for browser), Safari (YouTube) & Firefox (YouTube).\
 (4) You'll be prompted to let Übersicht use you geolocation.
 
@@ -32,7 +32,7 @@ A more "lite" & less ressource greedy version is available [here](https://github
 
 In order to make this custom bar work, you'll need to install both [yabai](https://github.com/koekeishiya/yabai) and [Übersicht](https://github.com/felixhageloh/uebersicht), both of them must be up to date. `simple-bar` supports both yabai v3 & yabai v4.
 
-Becareful, for Big Sur users (and above), some actions must be taken in order to make yabai fully operational: [see here for more details](<https://github.com/koekeishiya/yabai/wiki/Installing-yabai-(latest-release)#macos-big-sur---automatically-load-scripting-addition-on-startup>).
+Be careful, for Big Sur users (and above), some actions must be taken in order to make yabai fully operational: [see here for more details](<https://github.com/koekeishiya/yabai/wiki/Installing-yabai-(latest-release)#macos-big-sur---automatically-load-scripting-addition-on-startup>).
 
 **It is important to note that you'll need to use yabai in `bsp` or `stack` layout mode in order to prevent app windows to overlap simple-bar.**
 

--- a/lib/components/data/wifi.jsx
+++ b/lib/components/data/wifi.jsx
@@ -16,6 +16,7 @@ const {
   hideWifiIfDisabled,
   toggleWifiOnClick,
   networkDevice,
+  showNetworkName,
 } = networkWidgetOptions;
 
 const DEFAULT_REFRESH_FREQUENCY = 20000;
@@ -41,6 +42,7 @@ const openWifiPreferences = (e) => {
 
 const renderName = (name) => {
   if (!name) return "";
+  if (!showNetworkName) return "";
   if (name === "with an AirPort network.y off.") return "Disabled";
   if (name === "with an AirPort network.") return "Searching...";
   return name;

--- a/lib/components/data/wifi.jsx
+++ b/lib/components/data/wifi.jsx
@@ -41,8 +41,7 @@ const openWifiPreferences = (e) => {
 };
 
 const renderName = (name) => {
-  if (!name) return "";
-  if (hideNetworkName) return "";
+  if (!name || hideNetworkName) return "";
   if (name === "with an AirPort network.y off.") return "Disabled";
   if (name === "with an AirPort network.") return "Searching...";
   return name;
@@ -77,7 +76,10 @@ export const Widget = () => {
 
   if (hideWifiIfDisabled && !isActive) return null;
 
-  const classes = Utils.classnames("wifi", { "wifi--inactive": !isActive });
+  const classes = Utils.classnames("wifi", {
+    "wifi--hidden-name": !name,
+    "wifi--inactive": !isActive,
+  });
 
   const Icon = isActive ? Icons.Wifi : Icons.WifiOff;
 

--- a/lib/components/data/wifi.jsx
+++ b/lib/components/data/wifi.jsx
@@ -16,7 +16,7 @@ const {
   hideWifiIfDisabled,
   toggleWifiOnClick,
   networkDevice,
-  showNetworkName,
+  hideNetworkName,
 } = networkWidgetOptions;
 
 const DEFAULT_REFRESH_FREQUENCY = 20000;
@@ -42,7 +42,7 @@ const openWifiPreferences = (e) => {
 
 const renderName = (name) => {
   if (!name) return "";
-  if (!showNetworkName) return "";
+  if (hideNetworkName) return "";
   if (name === "with an AirPort network.y off.") return "Disabled";
   if (name === "with an AirPort network.") return "Searching...";
   return name;

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -241,6 +241,7 @@ export const data = {
   },
   hideWifiIfDisabled: { label: "Hide if disabled", type: "checkbox" },
   toggleWifiOnClick: { label: "Toggle Wifi onclick", type: "checkbox" },
+  showNetworkName: { label: "Show network name", type: "checkbox" },
 
   vpnWidgetOptions: {
     label: "Viscosity VPN",
@@ -441,6 +442,7 @@ export const defaultSettings = {
     networkDevice: "en0",
     hideWifiIfDisabled: false,
     toggleWifiOnClick: false,
+    showNetworkName: true,
   },
   vpnWidgetOptions: {
     refreshFrequency: 8000,

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -241,7 +241,7 @@ export const data = {
   },
   hideWifiIfDisabled: { label: "Hide if disabled", type: "checkbox" },
   toggleWifiOnClick: { label: "Toggle Wifi onclick", type: "checkbox" },
-  showNetworkName: { label: "Show network name", type: "checkbox" },
+  hideNetworkName: { label: "Hide network name", type: "checkbox" },
 
   vpnWidgetOptions: {
     label: "Viscosity VPN",
@@ -442,7 +442,7 @@ export const defaultSettings = {
     networkDevice: "en0",
     hideWifiIfDisabled: false,
     toggleWifiOnClick: false,
-    showNetworkName: true,
+    hideNetworkName: false,
   },
   vpnWidgetOptions: {
     refreshFrequency: 8000,

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -232,6 +232,7 @@ export const data = {
     infos: [
       "Here you can override the default displayed network source.",
       "And also turn Wifi on / off when clicking the Wifi icon.",
+      "Additionally, you can choose to hide the network name for privacy."
     ],
   },
   networkDevice: {

--- a/lib/styles/components/data/wifi.js
+++ b/lib/styles/components/data/wifi.js
@@ -6,4 +6,7 @@ export const wifiStyles = /* css */ `
   color: var(--red);
   background-color: transparent;
 }
+.wifi--hidden-name > svg {
+  margin-right: 0;
+}
 `;


### PR DESCRIPTION
# Readme
I added a missing space 
I also made it clear what the `cmd + t` shortcut does.

# Network name toggle
I added a toggle in settings for the network widget, that toggles if the name of the network should be shown. 

<img width="623" alt="Screenshot 2023-03-28 at 10 48 55" src="https://user-images.githubusercontent.com/77908661/228091746-ccb7b8d0-f77a-49a3-a4e6-ef1a3c66b642.png">
(What it looks like when toggled off)
<img width="43" alt="Screenshot 2023-03-28 at 10 50 12" src="https://user-images.githubusercontent.com/77908661/228091827-e55e07fa-f40d-412f-82d2-99d98cadbca3.png">

This fixes #324 