### PR TITLE
feat: use workspace shortcuts to switch space

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -321,14 +321,23 @@ export const timeout = (ms) =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
 export const switchSpace = async (currentIndex, desiredIndex) => {
-  const repeats = Math.abs(currentIndex - desiredIndex);
-  const left = currentIndex > desiredIndex;
-  for (let i = 0; i < repeats; i++) {
-    await Uebersicht.run(
-      `osascript -e 'tell app "System Events" to key code ${
-        left ? "123" : "124"
-      } using control down'`
-    );
+  if (desiredIndex > 10) {
+    const repeats = Math.abs(currentIndex - desiredIndex);
+    const left = currentIndex > desiredIndex;
+    for (let i = 0; i < repeats; i++) {
+      await Uebersicht.run(
+          `osascript -e 'tell app "System Events" to key code ${
+              left ? "123" : "124"
+          } using control down'`
+      );
+    }
+  } else {
+    const desktopkey = `\${desktophash[${desiredIndex}]}`
+    Uebersicht.run(`
+      desktophash=(29 18 19 20 21 23 22 26 28 25);
+      desktopkey=${desktopkey};
+      osascript -e "tell application \\"System Events\\" to key code $desktopkey using control down"
+    `)
   }
 };
 


### PR DESCRIPTION
This change updates the code to use workspace shortcuts for switching spaces when the desired index is 1-10.

```
"0" key: 29
"1" key: 18
"2" key: 19
"3" key: 20
"4" key: 21
"5" key: 23
"6" key: 22
"7" key: 26
"8" key: 28
"9" key: 25
```

for this to work of course the shortcut function for Misson-Control has to be enabled

![image](https://user-images.githubusercontent.com/3482021/236796300-6caf3d58-2142-465b-a8ca-4fe1ea3a39cd.png)
