### PR TITLE
Feature: add stack-index to process widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A more "lite" & less ressource greedy version is available [here](https://github
 - Navigate to workspace on click
 - For each space display an icon for every opened app (you can exclude specific apps/windows in settings based on process name or window title)
 - Show all opened apps (and current) in current space or simply current app name & title
+- Show all opened (or only focused) apps `stack-index` (from `yabai`) if you use stacking
 - Settings module (enable/disable each individual widget: see list below - switch dark/light theme) (1)
 - Spotify, Music/iTunes, browser current track (3)
 - Battery, microphone, sound level, wifi, date, time widgets

--- a/lib/components/spaces/window.jsx
+++ b/lib/components/spaces/window.jsx
@@ -8,9 +8,16 @@ const settings = Settings.get();
 
 const Window = ({ window }) => {
   const ref = Uebersicht.React.useRef();
-  const { displayOnlyCurrent, hideWindowTitle, displayOnlyIcon } =
+  const {
+    displayOnlyCurrent,
+    hideWindowTitle,
+    displayOnlyIcon,
+    displayStackIndex,
+    displayOnlyCurrentStack,
+  } =
     settings.process;
   const {
+    "stack-index": stackIndex,
     "is-minimized": isMinimized,
     minimized: __legacyIsMinimized,
     "has-focus": hasFocus,
@@ -57,6 +64,13 @@ const Window = ({ window }) => {
           <span className="process__name">{processName}</span>
         )}
       </span>
+      {displayStackIndex &&
+        (!displayOnlyCurrentStack || isFocused) &&
+        stackIndex > 0 && (
+        <span className="process__window process__stack_index">
+          {stackIndex}
+        </span>
+      )}
     </button>
   );
 };

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -106,6 +106,16 @@ export const data = {
     type: "checkbox",
     fullWidth: true,
   },
+  displayStackIndex: {
+    label: "Display stack-index for all processes in space (if greater than 0)",
+    type: "checkbox",
+    fullWidth: true,
+  },
+  displayOnlyCurrentStack: {
+    label: "Display stack-index only for focused process",
+    type: "checkbox",
+    fullWidth: true,
+  },
 
   spacesDisplay: {
     label: "Spaces",
@@ -393,6 +403,8 @@ export const defaultSettings = {
     showCurrentSpaceMode: false,
     hideWindowTitle: false,
     displayOnlyIcon: false,
+    displayStackIndex: true,
+    displayOnlyCurrentStack: false,
   },
   spacesDisplay: {
     exclusions: "",

--- a/lib/styles/components/process.js
+++ b/lib/styles/components/process.js
@@ -78,6 +78,15 @@ export const processStyles = /* css */ `
   color: var(--minor);
   background-color: var(--foreground);
 }
+.process__stack_index {
+  color: var(--red);
+  background-color: var(--foreground);
+}
+.process__window--focused .process__stack_index {
+  color: var(--foreground);
+  background-color: var(--red);
+  box-shadow: var(--foreground), 0 0 0 1px var(--light-shadow);
+}
 .simple-bar--widgets-background-color-as-foreground .process__window--focused {
   color: var(--foreground);
   background-color: transparent;


### PR DESCRIPTION
Let me know if this change isn't wanted in mainline! I know the author uses [stackline](https://github.com/AdamWagner/stackline) (which actually looks really cool), but I keep my margins very thin and don't have a whole lot of space for a stackline-like indicator.

I've implemented support for the process widget to show the yabai `stack-index` of the windows on the current space. Also added two config options: one for showing the stack indexes for the processes (default `true`) and one for only showing the stack-index for the focused window (default `false`). Looks like this:

(stack mode, only show index for focused window)
<img width="1680" alt="screenshot-230823-07-18-52" src="https://github.com/Jean-Tinland/simple-bar/assets/15623522/58d93211-10f3-4314-8f9a-70d875ed4fb8">

(bsp mode, show stack-index for all windows on space; there are two stacks on this space, which is why there are two groups of stack indexes)
<img width="1680" alt="screenshot-230823-07-15-23" src="https://github.com/Jean-Tinland/simple-bar/assets/15623522/39862795-a3fc-4f17-8200-769254e0c5ba">

I set the `color` (and `background-color`, for the focused process) to `var(--red)` to differentiate it slightly from the app/title text. 

As always, thanks for writing and maintaining this bar, I've been enjoying using it for years!

edit: forgot to say originally, but I tested this change with a few different configuration changes:
- display only current process name true/false
- center process widget true/false
- hide window titles true/false
- display only process icon true/false