### PR TITLE
Feature: show the current (non-default) skhd mode in process widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A more "lite" & less ressource greedy version is available [here](https://github
 - Dnd, crypto, weather & keyboard language input widgets (disabled by default) (4)
 - You can add your own custom widgets in settings (1)
 - **Only with SIP disabled**: create new workspace on "+" click, move or destroy workspace on space hover
+- Show current mode for `skhd`
 
 (1) Settings can be opened by pressing `cmd + ,` after clicking on **simple-bar** widget. More details in [Settings](#settings) section.\
 (2) Toggle dark/light mode by pressing `cmd + t` while focusing **simple-bar** (a light blue border should be visible at this moment).\
@@ -116,6 +117,29 @@ Feel free to open an issue if you want me to add a theme or if you created a the
 To use pywal colors instead, run the `pywal-gen.sh` script in `simple-bar > lib > styles > pywal`, then edit `simple-bar > lib > styles > theme.js` : `const WITH_PYWAL = false` must be set to "true".\
 This should be done after running `pywal`.\
 As I am not using this myself, I may have missed some problems, feel free to open an issue about it anytime.
+
+### `skhd` Mode Indicator
+
+Configuring a mode indicator for `skhd` requires defining on `on_enter` command for any modes you want to show. This `on_enter` command calls a script provided by `simple-bar` to cache the name of the mode as well as your preferred color (default color is white).
+
+You can use any color (e.g. the 8 standard shell colors) defined as a variable by simple-bar (see `./lib/styles/core/variables.js`, or the Uebersicht debug console).
+
+```
+# ~/.skhdrc
+
+# define a mode named "default". A mode named "default" will NOT be shown by simple-bar.
+:: default : ~/.config/ubersicht/widgets/simple-bar/lib/scripts/yabai-set-mode.sh default
+
+# define a mode named "tree" that will be colored blue
+:: tree : ~/.config/ubersicht/widgets/simple-bar/lib/scripts/yabai-set-mode.sh tree blue
+
+# define a mode called "binding" (in skhd) that will display in simple-bar as "binds"
+:: binding : ~/.config/ubersicht/widgets/simple-bar/lib/scripts/yabai-set-mode.sh binds green
+```
+
+The `yabai-set-mode.sh` script uses an AppleScript command to refresh `simple-bar`. That command requires permissions, which you can set in System Preferences > Privacy & Security > Automation > skhd > ubersicht.
+
+The mode indicator should appear within about a second after you enter a mode, in the process widget. You can debug this if it doesn't work by moving your mouse to different windows, or checking the skhd log/err files.
 
 ### Icons
 

--- a/index.jsx
+++ b/index.jsx
@@ -90,7 +90,7 @@ const render = ({ output, error }) => {
   const data = Utils.parseJson(output);
   if (!data) return <Error.Component type="noData" classes={baseClasses} />;
 
-  const { displays, shadow, SIP, spaces, windows } = data;
+  const { displays, shadow, skhd_mode, SIP, spaces, windows } = data;
 
   const displayId = parseInt(window.location.pathname.replace("/", ""));
   const { index: displayIndex } = displays.find((d) => {
@@ -116,6 +116,7 @@ const render = ({ output, error }) => {
           displayIndex={displayIndex}
           spaces={spaces}
           windows={windows}
+          skhdMode={skhd_mode}
         />
       )}
       <div className="simple-bar__data">

--- a/lib/components/spaces/process.jsx
+++ b/lib/components/spaces/process.jsx
@@ -6,7 +6,7 @@ export { processStyles as styles } from "../../styles/components/process";
 
 const settings = Settings.get();
 
-export const Component = ({ displayIndex, spaces, windows }) => {
+export const Component = ({ displayIndex, spaces, windows, skhdMode }) => {
   if (!windows) return null;
   const { process, spacesDisplay } = settings;
   const { exclusionsAsRegex } = spacesDisplay;
@@ -40,12 +40,20 @@ export const Component = ({ displayIndex, spaces, windows }) => {
     "process--centered": process.centered,
   });
 
+  const currentSkhdMode = skhdMode.mode === "default" ? null : skhdMode.mode;
+  const skhdModeColor = "var(--" + skhdMode.color + ")";
+
   return (
     <div className={classes}>
       <div className="process__container">
         {process.showCurrentSpaceMode && currentSpace && (
           <div key={currentSpace.index} className="process__layout">
             {currentSpace.type}
+          </div>
+        )}
+        {process.displaySkhdMode && currentSkhdMode && (
+          <div className="process__skhd_mode " style={{"backgroundColor": skhdModeColor}}>
+            {currentSkhdMode}
           </div>
         )}
         {Utils.sortWindows(apps).map((window, i) => (

--- a/lib/scripts/init.sh
+++ b/lib/scripts/init.sh
@@ -7,11 +7,14 @@ if [ $? -eq 1 ]; then
   exit 0
 fi
 
+SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
 spaces=$($yabai_path -m query --spaces)
 windows=$($yabai_path -m query --windows | sed 's/\\.//g; s/\n//g')
 displays=$($yabai_path -m query --displays)
 SIP=$(csrutil status)
 shadow_enabled=$($yabai_path -m config window_shadow)
+skhd_mode=$(cat "$("${SCRIPT_DIR}"/yabai-set-mode.sh --query)")
 
 if [ -z "$spaces" ]; then
   spaces=$($yabai_path -m query --spaces)
@@ -40,7 +43,8 @@ echo $(cat <<-EOF
     "windows": $windows,
     "displays": $displays,
     "SIP": "$SIP",
-    "shadow": "$shadow_enabled"
+    "shadow": "$shadow_enabled",
+    "skhd_mode": $skhd_mode
   }
 EOF
 )

--- a/lib/scripts/yabai-set-mode.sh
+++ b/lib/scripts/yabai-set-mode.sh
@@ -1,0 +1,40 @@
+#! /usr/bin/env sh
+
+# make sure to fix permissions!
+# Privacy & Security > Automation > skhd > Ubersicht
+
+# Write information regarding skhd mode to a cache file for widgets to read from.
+# Usage:
+#   $0 --query              print location of cache file
+#   $0 mode_name [color]    write mode_name (and optionally, a color) to a cache file
+#                           default color is white.
+#                           by default, a mode named "default" will not be shown.
+
+CACHE_FILE="$HOME/Library/Caches/uebersicht-simple-bar-index/yabai-mode"
+
+mkdir -p "$(dirname "$CACHE_FILE")"
+touch "$CACHE_FILE"
+
+main () {
+    # optional second argument color
+    color="$2"
+    if [ -z "$color" ]; then
+        color="white"
+    fi
+
+    # update cache file
+    echo \
+        "{\"mode\": \"$1\", \"color\": \"$color\"}" \
+        > "$CACHE_FILE"
+
+    osascript -e 'tell application id "tracesOf.Uebersicht" to refresh widget id "simple-bar-index-jsx"'
+}
+
+case "$1" in
+    --query)
+        echo "$CACHE_FILE"
+        ;;
+    *)
+        main "$@"
+        ;;
+esac

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -106,6 +106,11 @@ export const data = {
     type: "checkbox",
     fullWidth: true,
   },
+  displaySkhdMode: {
+    label: "Display current skhd mode (requires some configuration)",
+    type: "checkbox",
+    fullWidth: true,
+  },
 
   spacesDisplay: {
     label: "Spaces",
@@ -393,6 +398,7 @@ export const defaultSettings = {
     showCurrentSpaceMode: false,
     hideWindowTitle: false,
     displayOnlyIcon: false,
+    displaySkhdMode: false,
   },
   spacesDisplay: {
     exclusions: "",

--- a/lib/styles/components/process.js
+++ b/lib/styles/components/process.js
@@ -44,6 +44,21 @@ export const processStyles = /* css */ `
 	font-style: italic;
   text-transform: uppercase;
 }
+.process__skhd_mode {
+  display: flex;
+  align-items: center;
+  padding: var(--item-inner-margin);
+  font-family: var(--font);
+  font-size: var(--font-size);
+  border-radius: var(--item-radius);
+  box-shadow: var(--light-shadow);
+  font-style: italic;
+  text-transform: uppercase;
+
+  // different from process__layout
+  color: var(--foreground);
+  background-color: var(--minor);
+}
 .process__window {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Addressing https://github.com/Jean-Tinland/simple-bar/issues/205#issuecomment-1074408036, I've introduced another update to the process widget: this adds `skhd` mode next to the space layout IFF it's something other than the string `"default"`.

This one requires some configuration to set up (I've added notes in the readme):
1. define `on_enter` commands in `.skhdrc` to call a new simple-bar bash script. This script will simply cache the given mode name, and optionally a color (default white).
2. enable System Preferences > Privacy & Security > Automation > skhd > ubersicht, to allow `skhd` to issue AppleScript commands to Ubersicht.

I've added a setting for this to the process widget settings.

The logic that determines whether to display the `span` for the mode name will NOT print anything if the mode name is `"default"`. I've **assumed this default** since that's used in the example skhdrc provided by the author. Should this be a config setting? Show mode name regardless of name?

Do let me know if you have changes you think would be helpful for the readme/configuration/the way the script is set up.

----

some screenshots:

during `default` mode (i.e. normal operation)
<img width="1680" alt="Screenshot 2023-08-24 at 2 40 54 AM" src="https://github.com/Jean-Tinland/simple-bar/assets/15623522/f697b748-5d24-4429-87f7-7cc92a9207b0">

(display current layout: `false`)
<img width="1680" alt="Screenshot 2023-08-24 at 2 41 43 AM" src="https://github.com/Jean-Tinland/simple-bar/assets/15623522/3e396ab1-7925-405e-85b2-926968c017b3">

(display current layout: `true`)
<img width="1680" alt="Screenshot 2023-08-24 at 2 41 08 AM" src="https://github.com/Jean-Tinland/simple-bar/assets/15623522/b296251a-2b29-4d61-848b-f3591fe68dfa">


