### PR TITLE
Refresh bar when spaces are created and destroyed

### DIFF
--- a/lib/scripts/init.sh
+++ b/lib/scripts/init.sh
@@ -33,6 +33,8 @@ $yabai_path -m signal --add event=window_resized action="osascript -e 'tell appl
 $yabai_path -m signal --add event=window_destroyed action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-index-jsx\"'" label="Refresh simple-bar when an application window is closed"
 $yabai_path -m signal --add event=window_title_changed action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-index-jsx\"'" label="Refresh simple-bar when current window title changes"
 $yabai_path -m signal --add event=space_changed action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-index-jsx\"'" label="Refresh simple-bar on space change"
+$yabai_path -m signal --add event=space_destroyed action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-index-jsx\"'" label="Refresh simple-bar on space destroy"
+$yabai_path -m signal --add event=space_created action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-index-jsx\"'" label="Refresh simple-bar on space create"
 $yabai_path -m signal --add event=display_changed action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-index-jsx\"'" label="Refresh simple-bar on display focus change"
 
 if [ $display_skhd_mode = "true" ]; then


### PR DESCRIPTION
Problem: simple-bar did not show created spaces until the next refresh (e.g. by switching spaces). It also kept showing destroyed spaces until the next refresh.

Solution: Add missing yabai signals for the following events:
* space_destroyed
* space_created