### PR TITLE
Feature: Add Acrobat Reader and Texts Icon

### DIFF
--- a/lib/app-icons.js
+++ b/lib/app-icons.js
@@ -2,6 +2,7 @@ import * as Icons from "./components/icons.jsx";
 
 export const apps = {
   "1Password 7": Icons.OnePassword,
+  "Acrobat Reader": Icons.PDF,
   "Affinity Designer": Icons.AffinityDesigner,
   "Affinity Photo": Icons.AffinityPhoto,
   "Affinity Publisher": Icons.AffinityPublisher,
@@ -93,6 +94,7 @@ export const apps = {
   Telegram: Icons.Telegram,
   "Microsoft Teams": Icons.Teams,
   Terminal: Icons.Terminal,
+  Texts: Icons.Messages,
   Things: Icons.Things,
   Transmit: Icons.Transmit,
   Tweetbot: Icons.Twitter,


### PR DESCRIPTION
Added icons for
* [Acrobat Reader](https://www.adobe.com/acrobat/pdf-reader.html)
* [Texts](https://texts.com/)

Rationale behind adding Messages Icon to Texts 
* Texts users should in theory not have a need to open Messages so users will not be confused. 
* I was unable to find a good SVG of Texts Icon


| Acrobat Reader | Texts |
|--------|--------|
| <img width="212" alt="image" src="https://github.com/Jean-Tinland/simple-bar/assets/56021409/7b3baf88-b73a-4b0f-9c7c-e08b4cc2abf6"> | <img width="169" alt="image" src="https://github.com/Jean-Tinland/simple-bar/assets/56021409/55f7cdca-9302-44cd-a93c-19f98d698198"> | 




