### PR TITLE
Hide widgets container when none are enabled

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -34,6 +34,9 @@ const refreshFrequency = false;
 const settings = Settings.get();
 const { yabaiPath = "/usr/local/bin/yabai", shell } = settings.global;
 const { processWidget } = settings.widgets;
+const hasAnyWidgetEnabled = Object.entries(settings.widgets)
+  .filter(([widgetName]) => widgetName !== "processWidget")
+  .some(([_, enabled]) => enabled);
 const { hideWindowTitle, displayOnlyIcon, displaySkhdMode } = settings.process;
 
 const enableTitleChangedSignal = hideWindowTitle || displayOnlyIcon;
@@ -127,28 +130,30 @@ const render = ({ output, error }) => {
           skhdMode={skhdMode}
         />
       )}
-      <div className="simple-bar__data">
-        <Settings.Wrapper />
-        <UserWidgets display={displayIndex} />
-        <Zoom.Widget display={displayIndex} />
-        <BrowserTrack.Widget display={displayIndex} />
-        <Spotify.Widget display={displayIndex} />
-        <Crypto.Widget display={displayIndex} />
-        <Stock.Widget display={displayIndex} />
-        <Music.Widget display={displayIndex} />
-        <Mpd.Widget display={displayIndex} />
-        <Weather.Widget display={displayIndex} />
-        <Netstats.Widget display={displayIndex} />
-        <Cpu.Widget display={displayIndex} />
-        <Battery.Widget display={displayIndex} />
-        <Mic.Widget display={displayIndex} />
-        <Sound.Widget display={displayIndex} />
-        <ViscosityVPN.Widget display={displayIndex} />
-        <Wifi.Widget display={displayIndex} />
-        <Keyboard.Widget display={displayIndex} />
-        <DateDisplay.Widget display={displayIndex} />
-        <Time.Widget display={displayIndex} />
-      </div>
+      <Settings.Wrapper />
+      {hasAnyWidgetEnabled && (
+        <div className="simple-bar__data">
+          <UserWidgets display={displayIndex} />
+          <Zoom.Widget display={displayIndex} />
+          <BrowserTrack.Widget display={displayIndex} />
+          <Spotify.Widget display={displayIndex} />
+          <Crypto.Widget display={displayIndex} />
+          <Stock.Widget display={displayIndex} />
+          <Music.Widget display={displayIndex} />
+          <Mpd.Widget display={displayIndex} />
+          <Weather.Widget display={displayIndex} />
+          <Netstats.Widget display={displayIndex} />
+          <Cpu.Widget display={displayIndex} />
+          <Battery.Widget display={displayIndex} />
+          <Mic.Widget display={displayIndex} />
+          <Sound.Widget display={displayIndex} />
+          <ViscosityVPN.Widget display={displayIndex} />
+          <Wifi.Widget display={displayIndex} />
+          <Keyboard.Widget display={displayIndex} />
+          <DateDisplay.Widget display={displayIndex} />
+          <Time.Widget display={displayIndex} />
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION


# Description

Problem: When no widgets are enabled, there is still a small rectangle in the bottom right of the screen. The container itself is not hidden even when all widgets are disabled. It looks out of place.

Solution: Hide the container when all widgets are disabled.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] There is no container when all widgets are disabled
    
    <img width="1540" alt="image" src="https://github.com/Jean-Tinland/simple-bar/assets/889383/6eaf4fa7-8b83-4384-ba35-3c915724c5ef">

- [x] The container appears after enabling a widget
  
    
    <img width="1536" alt="image" src="https://github.com/Jean-Tinland/simple-bar/assets/889383/27d8f89e-5c78-4b80-90bb-0cd7dc30b976">


**Test Configuration**:

- OS version: Sonoma 14.1.1
- Yabai version: yabai-v6.0.1
- Übersicht version: Version 1.6 (82)

# Checklist:

- [ ] My code follows the style guidelines of this project

    I am not sure where the style guidelines are located. It passes `yarn lint`.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas

    I don't think it needs comments.

- [x] My changes generate no new warnings

# Changes to make to the documentation

None.