### PR TITLE
Icon for 1Password 8

### DIFF
--- a/lib/app-icons.js
+++ b/lib/app-icons.js
@@ -2,6 +2,7 @@ import * as Icons from "./components/icons.jsx";
 
 export const apps = {
   "1Password 7": Icons.OnePassword,
+  "1Password": Icons.OnePassword,
   "Acrobat Reader": Icons.PDF,
   "Activity Monitor": Icons.Activity,
   "Affinity Designer": Icons.AffinityDesigner,


### PR DESCRIPTION
# Description

The app title 1Password 8 is `1Password`, this will apply the existing 1Password icon to the new version of 1Password.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Verified app icon was applied.
