### PR TITLE
Restore window title signal functionality

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -43,7 +43,7 @@ const {
 const { hideWindowTitle, displayOnlyIcon, displaySkhdMode } = settings.process;
 
 const disableSignals = enableServer && yabaiServerRefresh;
-const enableTitleChangedSignal = hideWindowTitle || displayOnlyIcon;
+const enableTitleChangedSignal = !hideWindowTitle && !displayOnlyIcon;
 
 const args = `${yabaiPath} ${displaySkhdMode} ${disableSignals} ${enableTitleChangedSignal}`;
 const command = `${shell} simple-bar/lib/scripts/init.sh ${args}`;


### PR DESCRIPTION
# Description

I'm... pretty sure this has been wrong since this entire time? Window title changes never worked (in either yabai 6 or 7), but they do work now with this change. Apologies if I'm missing something obvious 😅 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Enable the process widget, without the two following options and check the registered yabai signals
<img width="381" alt="image" src="https://github.com/Jean-Tinland/simple-bar/assets/17962248/f1115b0b-45e1-4e02-9a45-dff5e8d2c01a">
```
❯ yabai -m signal --list | grep title | grep -v '""'
	"label":"Refresh simple-bar when current window title changes",
	"event":"window_title_changed",
```

This signal does not get registered at all without this PR, because the logic is flipped. (The above shell command returns nothing)

However, with any of the process widget options enabled, the signal will not get registered (make sure yabai is restarted, to avoid stray signals). Without this PR, the signal will get registered but will not be of any use.

**Test Configuration**:

- OS version: Sonoma 14.3, and 14.4
- Yabai version: v6.0.1, and v7.0.2
- Übersicht version: 1.6 (82)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
