### PR TITLE
Fix google chrome crash when searching on page (cmd+f)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
+.idea
 /node_modules
 package-lock.json

--- a/lib/scripts/init.sh
+++ b/lib/scripts/init.sh
@@ -14,7 +14,7 @@ SIP=$(csrutil status)
 shadow_enabled=$($yabai_path -m config window_shadow)
 
 spaces=$($yabai_path -m query --spaces)
-windows=$($yabai_path -m query --windows | sed 's/\n//g')
+windows=$($yabai_path -m query --windows)
 displays=$($yabai_path -m query --displays)
 
 if [ -z "$spaces" ]; then
@@ -22,8 +22,10 @@ if [ -z "$spaces" ]; then
 fi
 
 if [ -z "$windows" ]; then
-    windows=$($yabai_path -m query --windows | sed 's/\\.//g; s/\n//g')
+    windows=$($yabai_path -m query --windows | sed 's/\\.//g;')
 fi
+
+windows=$(echo $windows | tr -d '\n')
 
 if [ -z "$displays" ]; then
     displays=$($yabai_path -m query --displays)


### PR DESCRIPTION
# Description
In Google Chrome if I open the find window (cmd+f) it crashes the app with "unterminated string" JSON.parse error.
I saw that a fix was implemented in earlier versions, following the github issue: https://github.com/Jean-Tinland/simple-bar/issues/93

Fixes # (issue)
https://github.com/Jean-Tinland/simple-bar/issues/93

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
* Open Google Chrome
* Open https://github.com
* Press cmd+f
* simple-bar crashes and rerenders

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [ ] Open Google Chrome
- [ ] Open https://github.com
- [ ] Press cmd+f
- [ ] simple-bar should not crash

**Test Configuration**:

- OS version: Sonoma 14.2.1
- Yabai version: v7.1.0
- Übersicht version: 1.6

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

# Changes to make to the documentation

Please list any changes to the documentation that are required to reflect your changes.
