### PR TITLE
Weather Widget: Fix Location Lookup

### DIFF
--- a/lib/components/data/weather.jsx
+++ b/lib/components/data/weather.jsx
@@ -51,7 +51,15 @@ export const Widget = React.memo(() => {
     if (!location.current) {
       const position = await Promise.race([getPosition(), Utils.timeout(5000)]);
       if (!position) await getWeather();
-      location.current = position?.address?.city;
+
+      const coordinates = position?.position?.coords;
+      if (!coordinates) return setLoading(false);
+
+      const accuracy = 10 ** 2; // 2 decimal places
+      const latitute = Math.round(coordinates.latitude * accuracy) / accuracy;
+      const longitude = Math.round(coordinates.longitude * accuracy) / accuracy;
+
+      location.current = `${latitute},${longitude}`;
       if (!location.current) return setLoading(false);
     }
     try {


### PR DESCRIPTION
# Description

I work in a city that shares a name with a larger one. As such, the weather widget's call to `wttr.in` was incorrectly giving the weather for the larger city instead of my own.

This PR fixes the issue by instead fetching the weather based on a user's coordinates.

(Possibly) Related: #328

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

1. Observe weather widget with incorrect temp
2. Click on weather widget, observe incorrect city location
3. Merge changes
4. Observe weather widget with correct temp
5. Click on weather widget, observe correct city location

**Test Configuration**:

- OS version: `14.4.1 (23E224)`
- Yabai version: `yabai-v7.1.0`
- Übersicht version: `Version 1.6 (82)`

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

# Changes to make to the documentation

N/A