### PR TITLE
CPU Monitor Click Through

### DIFF
--- a/lib/components/data/cpu.jsx
+++ b/lib/components/data/cpu.jsx
@@ -19,7 +19,7 @@ export const Widget = React.memo(() => {
   const { displayIndex, settings } = useSimpleBarContext();
   const { widgets, cpuWidgetOptions } = settings;
   const { cpuWidget } = widgets;
-  const { refreshFrequency, showOnDisplay, displayAsGraph } = cpuWidgetOptions;
+  const { refreshFrequency, showOnDisplay, displayAsGraph, cpuMonitorApp } = cpuWidgetOptions;
 
   const visible =
     Utils.isVisibleOnDisplay(displayIndex, showOnDisplay) && cpuWidget;
@@ -65,9 +65,14 @@ export const Widget = React.memo(() => {
 
   const { usage } = state;
 
+  const onClick = cpuMonitorApp === "None" ? undefined : (e) => {
+    Utils.clickEffect(e);
+    openCpuUsageApp(cpuMonitorApp);
+  };
+
   if (displayAsGraph) {
     return (
-      <DataWidget.Widget classes="cpu cpu--graph" disableSlider>
+      <DataWidget.Widget classes="cpu cpu--graph" onClick={onClick} disableSlider>
         <Graph
           className="cpu__graph"
           caption={{
@@ -86,10 +91,21 @@ export const Widget = React.memo(() => {
   }
 
   return (
-    <DataWidget.Widget classes="cpu" Icon={Icons.CPU}>
+    <DataWidget.Widget classes="cpu" Icon={Icons.CPU} onClick={onClick}>
       <span className="cpu__usage">{usage}%</span>
     </DataWidget.Widget>
   );
 });
 
 Widget.displayName = "Cpu";
+
+function openCpuUsageApp(cpuUsageApp) {
+  switch (cpuUsageApp) {
+    case "Activity Monitor":
+      Uebersicht.run(`open -a "Activity Monitor"`);
+      break;
+    case "Top": 
+      Utils.runInUserTerminal('top')
+      break;
+  }
+}

--- a/lib/components/data/cpu.jsx
+++ b/lib/components/data/cpu.jsx
@@ -19,7 +19,8 @@ export const Widget = React.memo(() => {
   const { displayIndex, settings } = useSimpleBarContext();
   const { widgets, cpuWidgetOptions } = settings;
   const { cpuWidget } = widgets;
-  const { refreshFrequency, showOnDisplay, displayAsGraph, cpuMonitorApp } = cpuWidgetOptions;
+  const { refreshFrequency, showOnDisplay, displayAsGraph, cpuMonitorApp } =
+    cpuWidgetOptions;
 
   const visible =
     Utils.isVisibleOnDisplay(displayIndex, showOnDisplay) && cpuWidget;
@@ -65,14 +66,21 @@ export const Widget = React.memo(() => {
 
   const { usage } = state;
 
-  const onClick = cpuMonitorApp === "None" ? undefined : (e) => {
-    Utils.clickEffect(e);
-    openCpuUsageApp(cpuMonitorApp);
-  };
+  const onClick =
+    cpuMonitorApp === "None"
+      ? undefined
+      : (e) => {
+          Utils.clickEffect(e);
+          openCpuUsageApp(cpuMonitorApp);
+        };
 
   if (displayAsGraph) {
     return (
-      <DataWidget.Widget classes="cpu cpu--graph" onClick={onClick} disableSlider>
+      <DataWidget.Widget
+        classes="cpu cpu--graph"
+        onClick={onClick}
+        disableSlider
+      >
         <Graph
           className="cpu__graph"
           caption={{
@@ -104,8 +112,8 @@ function openCpuUsageApp(cpuUsageApp) {
     case "Activity Monitor":
       Uebersicht.run(`open -a "Activity Monitor"`);
       break;
-    case "Top": 
-      Utils.runInUserTerminal('top')
+    case "Top":
+      Utils.runInUserTerminal("top");
       break;
   }
 }

--- a/lib/scripts/run-command-in-iterm2.applescript
+++ b/lib/scripts/run-command-in-iterm2.applescript
@@ -1,0 +1,9 @@
+on run argv
+    set commandToRun to item 1 of argv
+    tell application "iTerm"
+        set newWindow to (create window with default profile)
+        tell current session of newWindow
+            write text commandToRun
+        end tell
+    end tell
+end run

--- a/lib/scripts/run-command-in-terminal.applescript
+++ b/lib/scripts/run-command-in-terminal.applescript
@@ -1,0 +1,7 @@
+on run argv
+    set commandToRun to item 1 of argv
+    tell application "Terminal"
+        do script commandToRun
+        activate
+    end tell
+end run

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -603,7 +603,7 @@ export const defaultSettings = {
     refreshFrequency: 2000,
     showOnDisplay: "",
     displayAsGraph: false,
-    cpuMonitorApp: "Top"
+    cpuMonitorApp: "Top",
   },
   batteryWidgetOptions: {
     refreshFrequency: 10000,

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -75,6 +75,12 @@ export const data = {
     type: "radio",
     options: ["sh", "bash", "dash"],
   },
+  terminal: {
+    title: "Which terminal should user facing commands be run in?",
+    label: "",
+    type: "radio",
+    options: ["Terminal", "iTerm2"],
+  },
   slidingAnimationPace: {
     label: "Sliding animation speed",
     type: "number",
@@ -300,6 +306,13 @@ export const data = {
     fullWidth: true,
   },
 
+  cpuMonitorApp: {
+    title: "Cpu Monitor",
+    label: "",
+    type: "radio",
+    options: ["Top", "Activity Monitor", "None"],
+  },
+
   batteryWidgetOptions: {
     label: "Battery",
     documentation: "/battery/",
@@ -515,6 +528,7 @@ export const defaultSettings = {
     fontSize: "11px",
     yabaiPath: "/usr/local/bin/yabai",
     shell: "sh",
+    terminal: "Terminal",
     slidingAnimationPace: 4,
     externalConfigFile: false,
     enableServer: false,
@@ -589,6 +603,7 @@ export const defaultSettings = {
     refreshFrequency: 2000,
     showOnDisplay: "",
     displayAsGraph: false,
+    cpuMonitorApp: "Top"
   },
   batteryWidgetOptions: {
     refreshFrequency: 10000,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -425,3 +425,24 @@ export function getRefreshFrequency(value, defaultValue) {
   const parsedValue = parseInt(value, 10);
   return isNaN(parsedValue) ? defaultValue : parsedValue;
 }
+
+export function runInUserTerminal(command) {
+  const settings = Settings.get();
+  const { terminal } = settings.global;
+  switch (terminal) {
+    case "Terminal": 
+      Uebersicht.run(
+        `osascript ./simple-bar/lib/scripts/run-command-in-terminal.applescript` +
+          ` "${command}"`
+      )
+      break;
+    case "iTerm2":
+      Uebersicht.run(
+        `osascript ./simple-bar/lib/scripts/run-command-in-iterm2.applescript` +
+          ` "${command}"`
+      ) 
+      break;
+    default:
+      break;
+  } 
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -430,19 +430,19 @@ export function runInUserTerminal(command) {
   const settings = Settings.get();
   const { terminal } = settings.global;
   switch (terminal) {
-    case "Terminal": 
+    case "Terminal":
       Uebersicht.run(
         `osascript ./simple-bar/lib/scripts/run-command-in-terminal.applescript` +
           ` "${command}"`
-      )
+      );
       break;
     case "iTerm2":
       Uebersicht.run(
         `osascript ./simple-bar/lib/scripts/run-command-in-iterm2.applescript` +
           ` "${command}"`
-      ) 
+      );
       break;
     default:
       break;
-  } 
+  }
 }


### PR DESCRIPTION
# Description

I was seeing spikes in CPU usage in simple bar, I was wondering what was causing the spikes and I found my self naturally clicking on the graph.

This lead me to add clicking on the widget to open a cpu monitor. I know people had different preferences about what should open so I made it configurable. Specifically I added 'top' and 'Activity Monitor' which both ship with macOS. I also added configurability to select which terminal 'top' runs in. I added two terminals "Terminal" and "iTerm2" I think this code has potentially to be useful in other parts of the project, but I cant for the life of me think of any good examples maybe people want to open "Spotify TUI" from simple bar given spotify behaves poorly with yabai? 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. 

There are the following possible options that have been tested:
- [✅] User has no CPU Monitor selected in settings
    - The label is not clickable
- [✅] User selects activity monitor in settings
    - Activity monitor should open up
- Top is selected in settings
    - [✅] User has terminal selected in settings
        - Terminal should open with top running
    - [✅] User has iTerm2 selected in settings 
        - iTerm2 should open with top running
    - [✅] User selects iTerm2 but iTerm2 is not installed
         - Nothing should happen

# Checklist:

- [ ✅] My code follows the style guidelines of this project
- [ ✅] I have performed a self-review of my code
- [✅ ] I have commented my code, particularly in hard-to-understand areas
- [✅ ] My changes generate no new warnings

# Changes to make to the documentation

None
