### PR TITLE
Fix newlines in yabai output

### DIFF
--- a/lib/scripts/init.sh
+++ b/lib/scripts/init.sh
@@ -22,7 +22,7 @@ if [ -z "$spaces" ]; then
 fi
 
 if [ -z "$windows" ]; then
-    windows=$($yabai_path -m query --windows | sed 's/\\.//g;' | tr -d '\n')
+    windows=$($yabai_path -m query --windows | sed 's/\\.//g;')
 fi
 
 if [ -z "$displays" ]; then
@@ -63,7 +63,7 @@ if [ $display_skhd_mode = "true" ]; then
     skhd_mode=$(cat "$("${SCRIPT_DIR}"/yabai-set-mode.sh --query)")
   else
     skhd_mode=$(cat "$("${SCRIPT_DIR}"/yabai-set-mode-server.sh --query)")
-  fi  
+  fi
 else
   skhd_mode="{}"
 fi
@@ -79,4 +79,4 @@ echo $(cat <<-EOF
     "skhdMode": $skhd_mode
   }
 EOF
-)
+) | tr -d '\n'


### PR DESCRIPTION
# Description

Whenever I `cmd + f` in my Google Chrome to search the web page, the parsing of the yabai windows output fails due to a newline in the output. Google Chrome will prefix the window title with "Find in page\n":
```json
{
  "title": "Find in page\n    Amazon Web Services Sign-In"
}
```
I'm not sure since when this was broken, possibly since f165275d1c87fed45129b99da0163459b6f87f0f, but reverting this commit still did not fix this issue.  I got it fixed by adding the `| tr -d '\n'` at the end instead.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I manually tested this.

Before my commit, it would show "... JSON error..." in the bar if I would `cmd + f` on a page. After my commit, it works normally.

**Test Configuration**:

- OS version Sonoma 14.5
- Yabai version yabai-v7.1.1
- Übersicht version Version 1.6 (82)
- Google Chrome version 124.0.6367.209

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
