### PR TITLE
Remove invisible U+200E unicode character from yabai query

### DIFF
--- a/lib/scripts/init.sh
+++ b/lib/scripts/init.sh
@@ -80,7 +80,7 @@ echo $(cat <<-EOF
   }
 EOF
 ) | \
-  # removes non-printable ASCII characters, https://alvinalexander.com/blog/post/linux-unix/how-remove-non-printable-ascii-characters-file-unix/
-  tr -cd '\11\12\15\40-\176' | \
+  # removes invisible U+200E Left-To-Right Mark character
+  sed "s/\xe2\x80\x8e//g" | \
   # removes newlines from output (handling Google Chrome JSON parse error caused by "search in page")
   tr -d '\n'

--- a/lib/scripts/init.sh
+++ b/lib/scripts/init.sh
@@ -79,4 +79,8 @@ echo $(cat <<-EOF
     "skhdMode": $skhd_mode
   }
 EOF
-) | tr -d '\n' # removes newlines from output (handling Google Chrome JSON parse error caused by "search in page")
+) | \
+  # removes non-printable ASCII characters, https://alvinalexander.com/blog/post/linux-unix/how-remove-non-printable-ascii-characters-file-unix/
+  tr -cd '\11\12\15\40-\176' | \
+  # removes newlines from output (handling Google Chrome JSON parse error caused by "search in page")
+  tr -d '\n'


### PR DESCRIPTION
# Description

If an app has an invisible U+200E character, it will not match the app name defined in `app-icons.js`. 

- Fixes #405 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- [x] Validated app names are dropping the U+200E character without affecting other unicode characters.

```
❯ queryTitle=$(yabai -m query --windows --space 1 | jq '.[].app')
❯ echo $queryTitle
"‎WhatsApp"

# get the ASCII value of the unicode character
❯ echo $queryTitle | hexdump -C
00000000  22 e2 80 8e 57 68 61 74  73 41 70 70 22 0a        |"...WhatsApp".|
0000000e

# compare to expected string without unicode character
❯ echo \"WhatsApp\" | hexdump -C
00000000  22 57 68 61 74 73 41 70  70 22 0a                 |"WhatsApp".|
0000000b


❯ echo $queryTitle
"‎WhatsApp"

# get number of bytes with string that contains hidden unicode character
❯ echo $queryTitle | wc -c
      14

# remove UTF-8 hex (e2 80 8e)
❯ echo $queryTitle | sed "s/\xe2\x80\x8e//g" | wc -c
      11
# compare number of bytes to string without unicode character
❯ echo \"WhatsApp\" | wc -c
      11


# does not affect other unicode characters, test with Chinese name for Finder
❯ echo $'\U8BBF'$'\U8FBE'
访达
❯ echo $'\U8BBF'$'\U8FBE' | wc -c
       7
❯ echo $'\U8BBF'$'\U8FBE' | sed "s/\xe2\x80\x8e//g"
访达
❯ echo $'\U8BBF'$'\U8FBE' | sed "s/\xe2\x80\x8e//g" | wc -c
       7
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

# Changes to make to the documentation

n/a
