### PR TITLE
Fix escaping JSON issues

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,9 +3,11 @@ import * as Settings from "./settings";
 
 export function parseJson(json) {
   try {
+    // clean up JSON that contains escape sequences,
+    // such as: `\\` or with `\"`
     let cleanedJson = json
-    .replace(/\\/g, "\\\\")
-    .replace(/\\\"/g, '"');
+      .replace(/\\/g, "\\\\")
+      .replace(/\\\"/g, '"');
     return JSON.parse(cleanedJson);
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,10 @@ import * as Settings from "./settings";
 
 export function parseJson(json) {
   try {
-    return JSON.parse(json);
+    let cleanedJson = json
+    .replace(/\\/g, "\\\\")
+    .replace(/\\\"/g, '"');
+    return JSON.parse(cleanedJson);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error, json);


### PR DESCRIPTION
# Description

Window titles with with escape sequences are not being parsed properly.

- Fixes #403

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Validated the following window titles are parsing and displaying correctly in simple-bar:
- [x] `simple-bar`
- [x] `\simple-\\bar`, previous error: `SyntaxError: JSON Parse error: Invalid escape character s`
- [x] `\"simple-\bar\"`, previous error: `SyntaxError: JSON Parse error: Expected '}'`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

# Changes to make to the documentation

n/a