### PR TITLE
Fix incorrect socket port in default settings

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -532,7 +532,7 @@ export const defaultSettings = {
     slidingAnimationPace: 4,
     externalConfigFile: false,
     enableServer: false,
-    serverSocketPort: 7776,
+    serverSocketPort: 7777,
     yabaiServerRefresh: false,
   },
   themes: {


### PR DESCRIPTION
# Description

Found that when trying to run a default setup without a config file setting the connection ports, the default settings would result in the socket being unable to connect as it would try to connect to the http port

Fixes #412 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- OS version [e.g. Sonoma 14.1.1]
- Yabai version [e.g. yabai-v6.0.1] (output of `yabai --version`)
- Übersicht version [e.g. Version 1.6 (82)]

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

# Changes to make to the documentation

Please list any changes to the documentation that are required to reflect your changes.
