### PR TITLE
Remove unused serverHttpPort config

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -94,12 +94,6 @@ export const data = {
     fullWidth: true,
   },
   externalConfigFile: { label: "External config file", type: "checkbox" },
-  serverHttpPort: {
-    label: "simple-bar-server http port",
-    type: "number",
-    placeholder: "Default: 7776",
-    fullWidth: true,
-  },
   serverSocketPort: {
     label: "simple-bar-server socket port",
     type: "number",


### PR DESCRIPTION
# Description

`serverHttpPort` is not in-used anywhere. Let's remove it

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
