### PR TITLE
fix: royal tsx app name

### DIFF
--- a/lib/app-icons.js
+++ b/lib/app-icons.js
@@ -143,7 +143,7 @@ export const apps = {
   Remnote: Icons.Remnote,
   Rider: Icons.Rider,
   "Rocket.Chat": Icons.RocketChat,
-  RoyalTSX: Icons.RoyalTSX,
+  "Royal TSX": Icons.RoyalTSX,
   RubyMine: Icons.RubyMine,
   RustRover: Icons.RustRover,
   "Safari Technology Preview": Icons.Safari,


### PR DESCRIPTION
# Description

This just fixes the application name for the newly added icon for Royal TSX.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Prior to change:
<img width="47" alt="Screenshot 2024-09-05 at 6 03 26 PM" src="https://github.com/user-attachments/assets/8461929f-56fb-4af7-b517-3ddb17255d29">

Post change:
<img width="55" alt="Screenshot 2024-09-05 at 6 02 37 PM" src="https://github.com/user-attachments/assets/534ea44f-11d8-46c7-a343-0b0d59d0580e">

**Test Configuration**:

- OS version: Sequoia 15.0 Beta
- Yabai version: yabai-v7.1.2
- Übersicht version: Version 1.6 (82)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings