### PR TITLE
Fixing yabaiPath bug.

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -36,11 +36,15 @@ const refreshFrequency = false;
 
 const settings = Settings.get();
 const {
-  yabaiPath = "/usr/local/bin/yabai",
   shell,
   enableServer,
   yabaiServerRefresh,
 } = settings.global;
+
+
+const yabaiPath = "/usr/local/bin/yabai";
+
+
 const { hideWindowTitle, displayOnlyIcon, displaySkhdMode } = settings.process;
 
 const disableSignals = enableServer && yabaiServerRefresh;


### PR DESCRIPTION
# Description

Fix for issue  #401 
This is the bug where yabaiPath is being over ridden, so its separated from the const group.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


- OS version [e.g. Sonoma 14.1.1]
- Yabai version [e.g. yabai-v6.0.1] (output of `yabai --version`)
- Übersicht version [e.g. Version 1.6 (82)]
