### PR TITLE
Add th-ch YouTube Music widget & icon

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -19,6 +19,7 @@ import * as Wifi from "./lib/components/data/wifi.jsx";
 import * as ViscosityVPN from "./lib/components/data/viscosity-vpn.jsx";
 import * as Keyboard from "./lib/components/data/keyboard.jsx";
 import * as Spotify from "./lib/components/data/spotify.jsx";
+import * as YouTubeMusic from "./lib/components/data/youtube-music.jsx";
 import * as Crypto from "./lib/components/data/crypto.jsx";
 import * as Stock from "./lib/components/data/stock.jsx";
 import * as Music from "./lib/components/data/music.jsx";
@@ -71,6 +72,7 @@ Utils.injectStyles("simple-bar-index-styles", [
   Mic.styles,
   Sound.styles,
   Spotify.styles,
+  YouTubeMusic.styles,
   Music.styles,
   Mpd.styles,
   BrowserTrack.styles,
@@ -140,6 +142,7 @@ function render({ output, error }) {
           <Zoom.Widget />
           <BrowserTrack.Widget />
           <Spotify.Widget />
+          <YouTubeMusic.Widget />
           <Crypto.Widget />
           <Stock.Widget />
           <Music.Widget />

--- a/lib/app-icons.js
+++ b/lib/app-icons.js
@@ -197,6 +197,7 @@ export const apps = {
   WezTerm: Icons.Terminal,
   WhatsApp: Icons.WhatsApp,
   Xcode: Icons.Xcode,
+  "YouTube Music": Icons.YoutubeMusic,
   zathura: Icons.PDF,
   Zed: Icons.Zed,
   Zeplin: Icons.Zeplin,

--- a/lib/components/data/youtube-music.jsx
+++ b/lib/components/data/youtube-music.jsx
@@ -1,0 +1,132 @@
+import * as Uebersicht from "uebersicht";
+import * as DataWidget from "./data-widget.jsx";
+import useWidgetRefresh from "../../hooks/use-widget-refresh";
+import useServerSocket from "../../hooks/use-server-socket";
+import { useSimpleBarContext } from "../simple-bar-context.jsx";
+import * as Icons from "../icons/icons.jsx";
+import * as Utils from "../../utils";
+
+export { youtubeMusicStyles as styles } from "../../styles/components/data/youtube-music";
+
+const { React } = Uebersicht;
+
+const DEFAULT_REFRESH_FREQUENCY = 10000;
+
+export const Widget = React.memo(() => {
+  const { displayIndex, settings } = useSimpleBarContext();
+  const {
+    widgets: { youtubeMusicWidget },
+    youtubeMusicWidgetOptions: {
+      refreshFrequency,
+      showSpecter,
+      showOnDisplay,
+      youtubeMusicPort,
+    },
+  } = settings;
+
+  const refresh = React.useMemo(
+    () =>
+      Utils.getRefreshFrequency(refreshFrequency, DEFAULT_REFRESH_FREQUENCY),
+    [refreshFrequency]
+  );
+
+  const visible =
+    Utils.isVisibleOnDisplay(displayIndex, showOnDisplay) && youtubeMusicWidget;
+
+  const [state, setState] = React.useState();
+  const [cachedAccessToken, setCachedAccessToken] = React.useState();
+
+  const resetWidget = () => {
+    setState(undefined);
+    setCachedAccessToken(undefined);
+  };
+
+  const getAccessToken = async () => {
+    // As of 2024/12/01, the generated access tokens don't expire
+    if (cachedAccessToken) return cachedAccessToken;
+
+    const authResp = await fetchRoute("/auth/simple-bar");
+    const auth = await authResp.json();
+    setCachedAccessToken(auth.accessToken);
+    return auth.accessToken;
+  };
+
+  const fetchRoute = React.useCallback(
+    async (route, method = "POST") => {
+      const headers = {};
+      const url = new URL(route, `http://localhost:${youtubeMusicPort}`);
+
+      // All routes under /api are protected
+      const needsAuthentication = url.pathname.startsWith("/api");
+      if (needsAuthentication) {
+        const accessToken = await getAccessToken();
+        if (!accessToken) {
+          throw new Error("Failed to get access token");
+        }
+        headers.Authorization = `Bearer ${accessToken}`;
+      }
+
+      return await fetch(url, { method, headers });
+    },
+    [youtubeMusicPort]
+  );
+
+  const refreshState = React.useCallback(async () => {
+    if (!visible) return;
+
+    try {
+      const currentStateResp = await fetchRoute("/api/v1/song-info", "GET");
+      const currentState = await currentStateResp.json();
+      setState(currentState);
+    } catch (e) {
+      // most likely due to offline server, reset state
+      resetWidget();
+    }
+  }, [visible, fetchRoute]);
+
+  useServerSocket("youtube-music", visible, refreshState, resetWidget);
+  useWidgetRefresh(visible, refreshState, refresh);
+
+  const onClick = async (e) => {
+    Utils.clickEffect(e);
+    await fetchRoute("/api/v1/toggle-play");
+    await refreshState();
+  };
+  const onRightClick = async (e) => {
+    Utils.clickEffect(e);
+    await fetchRoute("/api/v1/next");
+    await refreshState();
+  };
+  const onMiddleClick = async (e) => {
+    Utils.clickEffect(e);
+    Uebersicht.run(`open -a 'YouTube Music'`);
+    await refreshState();
+  };
+
+  const classes = Utils.classNames("youtube-music", {});
+  if (!state) return null;
+  const { title, artist, isPaused } = state;
+  if (!title) return null;
+
+  const label = artist.length ? `${title} - ${artist}` : title;
+  const Icon = getIcon(isPaused);
+
+  return (
+    <DataWidget.Widget
+      classes={classes}
+      Icon={Icon}
+      onClick={onClick}
+      onRightClick={onRightClick}
+      onMiddleClick={onMiddleClick}
+      showSpecter={showSpecter && !isPaused}
+    >
+      {label}
+    </DataWidget.Widget>
+  );
+});
+
+Widget.displayName = "YouTube Music";
+
+function getIcon(isPaused) {
+  return isPaused ? Icons.Paused : Icons.Playing;
+}

--- a/lib/components/icons/icons.jsx
+++ b/lib/components/icons/icons.jsx
@@ -284,6 +284,9 @@ export const Widget = React.lazy(() => import("./library/widget.jsx"));
 export const Wifi = React.lazy(() => import("./library/wifi.jsx"));
 export const WifiOff = React.lazy(() => import("./library/wifi-off.jsx"));
 export const Xcode = React.lazy(() => import("./library/xcode.jsx"));
+export const YoutubeMusic = React.lazy(() =>
+  import("./library/youtube-music.jsx")
+);
 export const Zed = React.lazy(() => import("./library/zed.jsx"));
 export const Zeplin = React.lazy(() => import("./library/zeplin.jsx"));
 export const Zoom = React.lazy(() => import("./library/zoom.jsx"));

--- a/lib/components/icons/library/youtube-music.jsx
+++ b/lib/components/icons/library/youtube-music.jsx
@@ -1,0 +1,13 @@
+import Icon from "../icon.jsx";
+
+export default function YoutubeMusic(props) {
+  return (
+    <Icon {...props}>
+      <path
+        fillRule="evenodd"
+        d="M12 24c6.627 0 12-5.373 12-12S18.627 0 12 0 0 5.373 0 12s5.373 12 12 12Zm0-17.727A5.735 5.735 0 0 1 17.727 12 5.727 5.727 0 0 1 12 17.727 5.727 5.727 0 0 1 6.273 12 5.735 5.735 0 0 1 12 6.273Zm0-.546a6.274 6.274 0 0 0 0 12.546 6.274 6.274 0 0 0 0-12.546Zm3.136 6.137-5.318 3.272V8.864l5.318 3Z"
+        clipRule="evenodd"
+      />
+    </Icon>
+  );
+}

--- a/lib/hooks/use-server-socket.js
+++ b/lib/hooks/use-server-socket.js
@@ -91,6 +91,7 @@ const settingsKeys = {
   "viscosity-vpn": "vpnWidget",
   weather: "weatherWidget",
   wifi: "wifiWidget",
+  "youtube-music": "youtubeMusicWidget",
   zoom: "zoomWidget",
 };
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -247,6 +247,7 @@ export const data = {
   batteryWidget: { label: "Battery", type: "checkbox" },
   keyboardWidget: { label: "Keyboard", type: "checkbox" },
   spotifyWidget: { label: "Spotify", type: "checkbox" },
+  youtubeMusicWidget: { label: "YouTube Music", type: "checkbox" },
   cryptoWidget: { label: "Crypto", type: "checkbox" },
   stockWidget: { label: "Stock", type: "checkbox" },
   musicWidget: { label: "Music/iTunes", type: "checkbox" },
@@ -412,6 +413,9 @@ export const data = {
     fullWidth: true,
   },
 
+  youtubeMusicWidgetOptions: {
+    label: "YouTube Music",
+  },
   spotifyWidgetOptions: {
     label: "Spotify",
     documentation: "/spotify/",
@@ -461,6 +465,7 @@ export const data = {
     documentation: "/browser-track/",
   },
   showSpecter: { label: "Show animated specter", type: "checkbox" },
+  youtubeMusicPort: { label: "Port", type: "text", placeholder: "26538" },
 
   denomination: { label: "Denomination", type: "text", placeholder: "usd" },
   identifiers: {
@@ -584,6 +589,7 @@ export const defaultSettings = {
     spotifyWidget: true,
     cryptoWidget: false,
     stockWidget: false,
+    youtubeMusicWidget: false,
     musicWidget: true,
     mpdWidget: false,
     browserTrackWidget: true,
@@ -682,6 +688,12 @@ export const defaultSettings = {
     refreshFrequency: 10000,
     showOnDisplay: "",
     showSpecter: true,
+  },
+  youtubeMusicWidgetOptions: {
+    refreshFrequency: 10000,
+    showOnDisplay: "",
+    showSpecter: true,
+    youtubeMusicPort: 26538,
   },
   musicWidgetOptions: {
     refreshFrequency: 10000,

--- a/lib/styles/components/data/youtube-music.js
+++ b/lib/styles/components/data/youtube-music.js
@@ -1,0 +1,11 @@
+export const youtubeMusicStyles = /* css */ `
+.youtube-music {
+  position: relative;
+  background-color: var(--red);
+}
+.simple-bar--widgets-background-color-as-foreground .youtube-music {
+  color: var(--red);
+  background-color: transparent;
+}
+`;
+


### PR DESCRIPTION
# Description

Adds support for https://github.com/th-ch/youtube-music

- Adds the YouTube Music icon for spaces
- Creates a opt-in widget that replicates the functionality of the Spotify widget
    - Utilizes the (default enabled) API server, allowing overrides of the default port

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

On fresh install:
- Verified the icon loads for YouTube Music windows
- Verified auth works as expected (**NOTE: a restart of YouTube Music is required after allowing `simple-bar` to access the API server**).
- Verified track changes change the status bar
- Verified a left click toggles play/pause
- Verified a right click skips the current song
- **NOTE: was not able to test middle click, as I use a trackpad**
    - However, running the CLI command in terminal does work as expected


**Test Configuration**:

- OS version: Sequoia 15.1.1
- Yabai version: yabai-v7.1.5
- Übersicht version: Version 1.6 (82)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

# Changes to make to the documentation

Nothing required up front, but would appreciate a doc similar to that of Spotify.
