### PR TITLE
fix: handled malformed JSON with empty array entries

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,6 +10,9 @@ import * as Settings from "./settings";
  */
 export function parseJson(json) {
   try {
+      // clean up JSON with escape sequences, (i.e.)
+      // empty arrays: [,] -> []
+      // escape sequences: \\" -> "
       let cleanedJson = json
           .replace(/\[,+/g, '[')      
           .replace(/,+\]/g, ']')
@@ -20,6 +23,7 @@ export function parseJson(json) {
           .replace(/\\"/g, '"');
       return JSON.parse(cleanedJson);
   } catch (error) {
+      // eslint-disable-next-line no-console
       console.error(error, json);
       return undefined;
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,14 +10,18 @@ import * as Settings from "./settings";
  */
 export function parseJson(json) {
   try {
-    // clean up JSON that contains escape sequences,
-    // such as: `\\` or with `\"`
-    let cleanedJson = json.replace(/\\/g, "\\\\").replace(/\\"/g, '"');
-    return JSON.parse(cleanedJson);
+      let cleanedJson = json
+          .replace(/\[,+/g, '[')      
+          .replace(/,+\]/g, ']')
+          .replace(/,+,/g, ',')
+          .replace(/\[,/g, '[')
+          .replace(/,\]/g, ']')
+          .replace(/\\/g, "\\\\")
+          .replace(/\\"/g, '"');
+      return JSON.parse(cleanedJson);
   } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error(error, json);
-    return undefined;
+      console.error(error, json);
+      return undefined;
   }
 }
 


### PR DESCRIPTION
# Description

This should fix the issue where yabai's JSON output containing empty array entries (represented as consecutive commas) would cause JSON.parse to fail, where it most commonly occurs in the `windows` array of yabai's output when window IDs are missing or undefined.

The fix adds regex-based sanitization to handle malformed array syntax before parsing, specifically:
- Removing consecutive commas in arrays
- Removing leading/trailing commas in arrays

This will prevent the bar from crashing when receiving malformed JSON from yabai.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with actual yabai output containing malformed arrays like:
```json
"windows": [,,,{ "id":1600, ... }]
```

The fix successfully parses this previously problematic output without errors.

**Test Configuration**:
- OS version: Sequoia 15.3
- yabai version: 7.1.8
- Übersicht version: 1.6

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

# Changes to make to the documentation

None required, this is a simple bug fix.