### PR TITLE
Ignore harmless yabai error when focusing already focused display

### DIFF
--- a/lib/yabai.js
+++ b/lib/yabai.js
@@ -30,7 +30,7 @@ export async function renameSpace(index, label) {
 export async function createSpace(displayId) {
   const settings = Settings.get();
   const { yabaiPath = "/opt/homebrew/bin/yabai" } = settings.global;
-  await Uebersicht.run(`${yabaiPath} -m display --focus ${displayId}`);
+  await focusDisplay(displayId)
   await Uebersicht.run(`${yabaiPath} -m space --create`);
   await Utils.softRefresh();
 }
@@ -43,7 +43,7 @@ export async function createSpace(displayId) {
 export async function removeSpace(index, displayId) {
   const settings = Settings.get();
   const { yabaiPath = "/opt/homebrew/bin/yabai" } = settings.global;
-  await Uebersicht.run(`${yabaiPath} -m display --focus ${displayId}`);
+  await focusDisplay(displayId)
   await Uebersicht.run(`${yabaiPath} -m space ${index} --destroy`);
   await Utils.softRefresh();
 }
@@ -103,4 +103,24 @@ export async function getDisplays() {
   const { yabaiPath = "/opt/homebrew/bin/yabai" } = settings.global;
   const json = await Uebersicht.run(`${yabaiPath} -m query --displays`);
   return Utils.parseJson(json);
+}
+
+
+/**
+ * Focus the given display.
+ *
+ * Silently ignores the error thrown when the display is already focused,
+ * which is a known and harmless yabai behavior.
+ *
+ * @param {number|string} displayId - The ID of the display to focus.
+ */
+async function focusDisplay(displayId) {
+  try {
+    await Uebersicht.run(`${yabaiPath} -m display --focus ${displayId}`);
+  } catch (e) {
+    const message = e?.toString?.() || '';
+    if (!message.includes('cannot focus an already focused display')) {
+      console.warn('Failed to focus display:', message);
+    }
+  }
 }


### PR DESCRIPTION
# Description

Yabai throws an error when attempting to focus a display that is already focused:  
`cannot focus an already focused display`.  

This harmless error was not caught, causing Übersicht's script execution to fail and preventing subsequent actions—like space creation or removal—from completing successfully.

This patch catches that specific error and silently ignores it, improving the robustness of the widget.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Installed a fresh setup of Yabai (with SIP disabled) following the documentation for Sequoia 15.4, along with Übersicht and a single plugin: simple-bar.
- [x] Verified that space creation and deletion **did not work** before the patch (only switching spaces worked after manually creating them).
- [x] Applied the proposed patch and confirmed that space creation and deletion started working properly.

**Test Configuration**:

- macOS Sequoia 15.4 (24E248)
- yabai version: v7.1.14
- Übersicht version: 1.6 (82)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (using JSDoc where applicable)
- [x] My changes generate no new warnings
