### PR TITLE
Ensure correct positioning for floating bottom bar

### DIFF
--- a/lib/styles/core/base.js
+++ b/lib/styles/core/base.js
@@ -40,6 +40,7 @@ const baseStyles = /* css */ `
   bottom: 0;
 }
 .simple-bar--floating.simple-bar--on-bottom {
+  top: unset;
   bottom: 5px;
 }
 .simple-bar--no-bar-background,


### PR DESCRIPTION
# Description

Resolve an issue where enabling both floating bar and bottom bar settings caused the bar to appear at the top of the screen. Adjusted styles to properly position the bar at the bottom when both settings are active.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Enable both floating bar and bottom bar in the general settings: the simple-bar is actually floating at the top of the screen
- [x] Add the following CSS on the custom style section solved the issue:

```css
.simple-bar--floating.simple-bar--on-bottom {
  top: unset;
  bottom: 10px;
}
```

Nota bene: I increase the bottom value for preferences, no need to update it. 👍 

**Test Configuration**:

- macOS Sequoia 15.4 (24E248)
- yabai version: v7.1.14
- Übersicht version: 1.6 (82)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (make use of JSDoc if necessary)
- [x] My changes generate no new warnings

