### PR TITLE
Fix: Enhance time widget visibility in foreground color mode

### DIFF
--- a/lib/styles/components/data/time.js
+++ b/lib/styles/components/data/time.js
@@ -24,6 +24,9 @@ export const timeStyles = /* css */ `
   touch-action: none;
   z-index: -1;
 }
+.simple-bar--widgets-background-color-as-foreground .time__filler {
+  background-color: transparent;
+}
 .time__icon {
   position: relative;
   flex: 0 0 15px;
@@ -32,6 +35,9 @@ export const timeStyles = /* css */ `
   margin-right: 7px;
   border: 1px solid var(--background);
   border-radius: 50%;
+}
+.simple-bar--widgets-background-color-as-foreground .time__icon {
+  border: 1px solid var(--yellow);
 }
 .simple-bar--no-color-in-data .time__icon {
   border: 1px solid var(--foreground);
@@ -47,6 +53,10 @@ export const timeStyles = /* css */ `
   transform-origin: bottom;
   transition: transform 160ms var(--transition-easing);
   will-change: transform;
+}
+.simple-bar--widgets-background-color-as-foreground .time__hours, 
+.simple-bar--widgets-background-color-as-foreground .time__minutes {
+  background-color: var(--yellow);
 }
 .simple-bar--no-color-in-data .time__hours,
 .simple-bar--no-color-in-data .time__minutes {


### PR DESCRIPTION
# Description

This PR fixes the time widget's icon visibility when the "Use background color as foreground for widgets" option is enabled. Previously, the icon still used the old foreground color, making it hard to see and leaving unnecessary space. Now, the icon uses the background color, improving clarity and consistency with other widgets.

Fixes: N/A (discovered and fixed directly — no linked issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This change was tested manually within Übersicht by toggling the "Use background color as foreground for widgets" setting and verifying that the clock widget's appearance remains consistent, readable, and aligned with other widgets.

**Test Configuration**:

- OS version: macOS Sonoma 14.5
- yabai version: yabai-v7.1.1  
- Übersicht version: Version 1.6 (82)  

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (not required for this visual fix)
- [x] My changes generate no new warnings

# Changes to make to the documentation

No documentation changes are required for this fix, as it modifies only the widget’s visual behavior.
