### PR TITLE
fix(battery): handle both lowpowermode and powermode for better compatibility across macs

### DIFF
--- a/lib/components/data/battery.jsx
+++ b/lib/components/data/battery.jsx
@@ -65,7 +65,9 @@ export const Widget = React.memo(() => {
           `pmset -g batt | grep "'.*'" | sed "s/'//g" | cut -c 18-19`
         ),
         Uebersicht.run(`pgrep caffeinate`),
-        Uebersicht.run(`pmset -g | grep lowpowermode | awk '{print $2}'`),
+        Uebersicht.run(
+          `pmset -g | grep -E 'lowpowermode|powermode' | awk '{print $2}'`
+        ),
       ]);
     setState({
       system,


### PR DESCRIPTION
# Description

This PR improves power mode handling across Mac models by supporting both `lowpowermode` and `powermode` keys in `pmset`. Macs with High Power Mode use the `powermode` key. For more details on High Power Mode, see [Apple's support page](https://support.apple.com/en-in/101613).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested on my Macbook M1 Air
- [x] Tested on my Macbook M4 Pro

**Test Configuration**:

- OS version: macOS Sequoia 15.4.1
- yabai version: yabai-v7.1.14
- Übersicht version: Version 1.6 (82)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings