### PR TITLE
Fix keyboard layout name parsing

### DIFF
--- a/lib/components/data/keyboard.jsx
+++ b/lib/components/data/keyboard.jsx
@@ -51,9 +51,11 @@ export const Widget = React.memo(() => {
   const getKeyboard = React.useCallback(async () => {
     if (!visible) return;
     const keyboard = await Uebersicht.run(
-      `defaults read ~/Library/Preferences/com.apple.HIToolbox.plist AppleSelectedInputSources | awk '/KeyboardLayout Name/ {print $4}'`
+      `defaults read ~/Library/Preferences/com.apple.HIToolbox.plist AppleSelectedInputSources | awk '/KeyboardLayout Name/ {$1=$2=$3=""; print $0}'`
     );
-    const layout = Utils.cleanupOutput(keyboard).replace(";", "");
+    const layout = Utils.cleanupOutput(keyboard)
+      .replace(";", "")
+      .replaceAll("\"", "");
     if (layout.length) {
       setState({ keyboard: layout });
       setLoading(false);
@@ -61,7 +63,7 @@ export const Widget = React.memo(() => {
     }
 
     const inputMode = await Uebersicht.run(
-      `defaults read ~/Library/Preferences/com.apple.HIToolbox.plist AppleSelectedInputSources | awk '/"Input Mode" =/ {print $4}'`
+      `defaults read ~/Library/Preferences/com.apple.HIToolbox.plist AppleSelectedInputSources | awk '/"Input Mode" =/ {$1=$2=$3=""; print $0}'`
     );
     const cleanedInputMode = Utils.cleanupOutput(inputMode)
       .replace(/"com.apple.inputmethod.(.*)"/, "$1")


### PR DESCRIPTION
# Description

When the layout name has a space, e.g. `Swiss French`, the keyboard widget will show `"Swiss`. Same with any other layout with a space in it.

<img width="121" alt="Image" src="https://github.com/user-attachments/assets/a69fa8f1-ce99-42c0-974f-20da87ebc0de" />

This is due to the command used to grab the keyboard layout being wrong:

https://github.com/Jean-Tinland/simple-bar/blob/f0d2c80283f7864b1b1f7d03a5911868f37560d8/lib/components/data/keyboard.jsx#L53-L55

```
❯ defaults read ~/Library/Preferences/com.apple.HIToolbox.plist AppleSelectedInputSources | grep "KeyboardLayout Name"
        "KeyboardLayout Name" = "Swiss French";
❯ defaults read ~/Library/Preferences/com.apple.HIToolbox.plist AppleSelectedInputSources | awk '/KeyboardLayout Name/ {print $4}'
"Swiss
```

This PR makes `awk` print "everything from $4" instead of "only $4". It also gets rid of the extraneous quotes as a result.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It now works with any layout, built-in or custom, without having changed anything in the already-working layouts.

<img width="148" alt="image" src="https://github.com/user-attachments/assets/e2e0fa27-9c55-4cbf-a364-a6bb802b0c08" />

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (make use of JSDoc if necessary)
- [x] My changes generate no new warnings