### PR TITLE
feat: adds icon toggle to widgets

### DIFF
--- a/lib/components/data/battery.jsx
+++ b/lib/components/data/battery.jsx
@@ -27,6 +27,7 @@ export const Widget = React.memo(() => {
     toggleCaffeinateOnClick,
     caffeinateOption,
     showOnDisplay,
+    showIcon,
   } = batteryWidgetOptions;
 
   // Determine if the widget should be visible based on display settings
@@ -129,7 +130,7 @@ export const Widget = React.memo(() => {
   return (
     <DataWidget.Widget
       classes={classes}
-      Icon={Icon}
+      Icon={showIcon ? Icon : null}
       disableSlider
       {...onClickProp}
     >

--- a/lib/components/data/browser-track.jsx
+++ b/lib/components/data/browser-track.jsx
@@ -22,7 +22,7 @@ export const Widget = React.memo(() => {
   const { displayIndex, settings } = useSimpleBarContext();
   const { widgets, browserTrackWidgetOptions } = settings;
   const { browserTrackWidget } = widgets;
-  const { refreshFrequency, showSpecter, showOnDisplay } =
+  const { refreshFrequency, showSpecter, showOnDisplay, showIcon } =
     browserTrackWidgetOptions;
   const visible =
     Utils.isVisibleOnDisplay(displayIndex, showOnDisplay) && browserTrackWidget;
@@ -119,7 +119,7 @@ export const Widget = React.memo(() => {
     <DataWidget.Widget
       ref={ref}
       classes="browser-track"
-      Icon={Icon}
+      Icon={showIcon ? Icon : null}
       showSpecter={showSpecter}
     >
       {title}

--- a/lib/components/data/cpu.jsx
+++ b/lib/components/data/cpu.jsx
@@ -23,7 +23,7 @@ export const Widget = React.memo(() => {
   const { displayIndex, settings } = useSimpleBarContext();
   const { widgets, cpuWidgetOptions } = settings;
   const { cpuWidget } = widgets;
-  const { refreshFrequency, showOnDisplay, displayAsGraph, cpuMonitorApp } =
+  const { refreshFrequency, showOnDisplay, displayAsGraph, cpuMonitorApp, showIcon } =
     cpuWidgetOptions;
 
   // Determine if the widget should be visible based on display settings
@@ -101,7 +101,7 @@ export const Widget = React.memo(() => {
           caption={{
             usage: {
               value: `${usage}%`,
-              icon: Icons.CPU,
+              icon: showIcon ? Icons.CPU : null,
               color: "var(--yellow)",
             },
           }}
@@ -114,7 +114,7 @@ export const Widget = React.memo(() => {
   }
 
   return (
-    <DataWidget.Widget classes="cpu" Icon={Icons.CPU} onClick={onClick}>
+    <DataWidget.Widget classes="cpu" Icon={showIcon ? Icons.CPU : null} onClick={onClick}>
       <span className="cpu__usage">{usage}%</span>
     </DataWidget.Widget>
   );

--- a/lib/components/data/crypto.jsx
+++ b/lib/components/data/crypto.jsx
@@ -27,6 +27,7 @@ export const Widget = React.memo(() => {
     identifiers,
     precision,
     showOnDisplay,
+    showIcon,
   } = cryptoWidgetOptions;
 
   // Calculate the refresh frequency using the provided or default value
@@ -105,7 +106,7 @@ export const Widget = React.memo(() => {
       key={id}
       classes={classes}
       ref={ref}
-      Icon={getIcon(id)}
+      Icon={showIcon ? getIcon(id) : null}
       href={`https://coingecko.com/en/coins/${id}`}
       onClick={(e) => openCrypto(e, pushMissive)}
       onRightClick={refreshCrypto}

--- a/lib/components/data/date-display.jsx
+++ b/lib/components/data/date-display.jsx
@@ -27,6 +27,7 @@ export const Widget = React.memo(() => {
     locale,
     calendarApp,
     showOnDisplay,
+    showIcon,
   } = dateWidgetOptions;
 
   // Determine if the widget should be visible based on display settings
@@ -97,7 +98,7 @@ export const Widget = React.memo(() => {
   return (
     <DataWidget.Widget
       classes="date-display"
-      Icon={Icons.Date}
+      Icon={showIcon ? Icons.Date : null}
       onClick={onClick}
     >
       {now}

--- a/lib/components/data/gpu.jsx
+++ b/lib/components/data/gpu.jsx
@@ -28,6 +28,7 @@ export const Widget = React.memo(() => {
     showOnDisplay,
     displayAsGraph,
     gpuMacmonBinaryPath,
+    showIcon,
   } = gpuWidgetOptions;
 
   const isDisabled = React.useRef(false);
@@ -102,7 +103,7 @@ export const Widget = React.memo(() => {
           caption={{
             usage: {
               value: `${usage}%`,
-              icon: Icons.CPU,
+              icon: showIcon ? Icons.CPU : null,
               color: "var(--cyan)",
             },
           }}
@@ -115,7 +116,7 @@ export const Widget = React.memo(() => {
   }
 
   return (
-    <DataWidget.Widget classes="cpu" Icon={Icons.CPU}>
+    <DataWidget.Widget classes="cpu" Icon={showIcon ? Icons.CPU : null}>
       <span className="cpu__usage">{usage}%</span>
     </DataWidget.Widget>
   );

--- a/lib/components/data/keyboard.jsx
+++ b/lib/components/data/keyboard.jsx
@@ -21,7 +21,7 @@ export const Widget = React.memo(() => {
   const { displayIndex, settings } = useSimpleBarContext();
   const { widgets, keyboardWidgetOptions } = settings;
   const { keyboardWidget } = widgets;
-  const { refreshFrequency, showOnDisplay } = keyboardWidgetOptions;
+  const { refreshFrequency, showOnDisplay, showIcon } = keyboardWidgetOptions;
 
   // Determine the refresh frequency for the widget
   const refresh = React.useMemo(
@@ -89,7 +89,7 @@ export const Widget = React.memo(() => {
   if (!keyboard?.length) return null;
 
   return (
-    <DataWidget.Widget classes="keyboard" Icon={Icons.Keyboard}>
+    <DataWidget.Widget classes="keyboard" Icon={showIcon ? Icons.Keyboard : null}>
       {keyboard}
     </DataWidget.Widget>
   );

--- a/lib/components/data/memory.jsx
+++ b/lib/components/data/memory.jsx
@@ -20,7 +20,7 @@ export const Widget = () => {
   const { displayIndex, settings } = useSimpleBarContext();
   const { widgets, memoryWidgetOptions } = settings;
   const { memoryWidget } = widgets;
-  const { refreshFrequency, showOnDisplay, memoryMonitorApp } =
+  const { refreshFrequency, showOnDisplay, memoryMonitorApp, showIcon } =
     memoryWidgetOptions;
 
   // Determine the refresh frequency for the widget
@@ -99,7 +99,7 @@ export const Widget = () => {
   });
 
   return (
-    <DataWidget.Widget classes={classes} Icon={Pie} onClick={onClick}>
+    <DataWidget.Widget classes={classes} Icon={showIcon ? Pie : null} onClick={onClick}>
       <div className="memory__content">{used}%</div>
     </DataWidget.Widget>
   );

--- a/lib/components/data/mic.jsx
+++ b/lib/components/data/mic.jsx
@@ -22,7 +22,7 @@ export const Widget = React.memo(() => {
   const { displayIndex, settings } = useSimpleBarContext();
   const { widgets, micWidgetOptions } = settings;
   const { micWidget } = widgets;
-  const { refreshFrequency, showOnDisplay } = micWidgetOptions;
+  const { refreshFrequency, showOnDisplay, showIcon } = micWidgetOptions;
 
   // Determine the refresh frequency for the widget.
   const refresh = React.useMemo(
@@ -115,9 +115,11 @@ export const Widget = React.memo(() => {
   return (
     <DataWidget.Widget classes={classes} disableSlider>
       <div className="mic__display">
-        <SuspenseIcon>
-          <Icon />
-        </SuspenseIcon>
+        {showIcon && (
+          <SuspenseIcon>
+            <Icon />
+          </SuspenseIcon>
+        )}
         <span className="mic__value">{formattedVolume}</span>
       </div>
       <div className="mic__slider-container">

--- a/lib/components/data/mpd.jsx
+++ b/lib/components/data/mpd.jsx
@@ -30,6 +30,7 @@ export const Widget = React.memo(() => {
     mpdPort,
     mpdFormatString,
     showOnDisplay,
+    showIcon,
   } = mpdWidgetOptions;
 
   // Determine the refresh frequency for the widget
@@ -165,7 +166,7 @@ export const Widget = React.memo(() => {
   return (
     <DataWidget.Widget
       classes={classes}
-      Icon={Icon}
+      Icon={showIcon ? Icon : null}
       onClick={onClick}
       showSpecter={showSpecter && isPlaying}
       disableSlider

--- a/lib/components/data/music.jsx
+++ b/lib/components/data/music.jsx
@@ -21,7 +21,7 @@ export const Widget = React.memo(() => {
   const { displayIndex, settings } = useSimpleBarContext();
   const { widgets, musicWidgetOptions } = settings;
   const { musicWidget } = widgets;
-  const { refreshFrequency, showSpecter, showOnDisplay } = musicWidgetOptions;
+  const { refreshFrequency, showSpecter, showOnDisplay, showIcon } = musicWidgetOptions;
 
   // Determine the refresh frequency for the widget
   const refresh = React.useMemo(
@@ -137,7 +137,7 @@ export const Widget = React.memo(() => {
   return (
     <DataWidget.Widget
       classes={classes}
-      Icon={Icon}
+      Icon={showIcon ? Icon : null}
       onClick={onClick}
       onRightClick={onRightClick}
       onMiddleClick={onMiddleClick}

--- a/lib/components/data/netstats.jsx
+++ b/lib/components/data/netstats.jsx
@@ -24,7 +24,7 @@ export const Widget = React.memo(() => {
   const { displayIndex, settings } = useSimpleBarContext();
   const { widgets, netstatsWidgetOptions } = settings;
   const { netstatsWidget } = widgets;
-  const { refreshFrequency, showOnDisplay, displayAsGraph } =
+  const { refreshFrequency, showOnDisplay, displayAsGraph, showIcon } =
     netstatsWidgetOptions;
 
   const isDisabled = React.useRef(false);
@@ -115,12 +115,12 @@ export const Widget = React.memo(() => {
           caption={{
             download: {
               value: formattedDownload,
-              icon: Icons.Download,
+              icon: showIcon ? Icons.Download : null,
               color: "var(--magenta)",
             },
             upload: {
               value: formattedUpload,
-              icon: Icons.Upload,
+              icon: showIcon ? Icons.Upload : null,
               color: "var(--blue)",
             },
           }}
@@ -135,9 +135,11 @@ export const Widget = React.memo(() => {
     <React.Fragment>
       <DataWidget.Widget classes="netstats" disableSlider>
         <div className="netstats__item">
-          <SuspenseIcon>
-            <Icons.Download className="netstats__icon netstats__icon--download" />
-          </SuspenseIcon>
+          {showIcon && (
+            <SuspenseIcon>
+              <Icons.Download className="netstats__icon netstats__icon--download" />
+            </SuspenseIcon>
+          )}
           <span
             className="netstats__value"
             dangerouslySetInnerHTML={{ __html: formattedDownload }}
@@ -146,9 +148,11 @@ export const Widget = React.memo(() => {
       </DataWidget.Widget>
       <DataWidget.Widget classes="netstats" disableSlider>
         <div className="netstats__item">
-          <SuspenseIcon>
-            <Icons.Upload className="netstats__icon netstats__icon--upload" />
-          </SuspenseIcon>
+          {showIcon && (
+            <SuspenseIcon>
+              <Icons.Upload className="netstats__icon netstats__icon--upload" />
+            </SuspenseIcon>
+          )}
           <span
             className="netstats__value"
             dangerouslySetInnerHTML={{ __html: formattedUpload }}

--- a/lib/components/data/sound.jsx
+++ b/lib/components/data/sound.jsx
@@ -22,7 +22,7 @@ export const Widget = React.memo(() => {
   const { displayIndex, settings } = useSimpleBarContext();
   const { widgets, soundWidgetOptions } = settings;
   const { soundWidget } = widgets;
-  const { refreshFrequency, showOnDisplay } = soundWidgetOptions;
+  const { refreshFrequency, showOnDisplay, showIcon } = soundWidgetOptions;
 
   // Determine the refresh frequency for the widget.
   const refresh = React.useMemo(
@@ -118,9 +118,11 @@ export const Widget = React.memo(() => {
   return (
     <DataWidget.Widget classes={classes} disableSlider>
       <div className="sound__display">
-        <SuspenseIcon>
-          <Icon />
-        </SuspenseIcon>
+        {showIcon && (
+          <SuspenseIcon>
+            <Icon />
+          </SuspenseIcon>
+        )}
         <span className="sound__value">{formattedVolume}</span>
       </div>
       <div className="sound__slider-container">

--- a/lib/components/data/spotify.jsx
+++ b/lib/components/data/spotify.jsx
@@ -21,7 +21,7 @@ export const Widget = React.memo(() => {
   const { displayIndex, settings } = useSimpleBarContext();
   const { widgets, spotifyWidgetOptions } = settings;
   const { spotifyWidget } = widgets;
-  const { refreshFrequency, showSpecter, showOnDisplay } = spotifyWidgetOptions;
+  const { refreshFrequency, showSpecter, showOnDisplay, showIcon } = spotifyWidgetOptions;
 
   // Determine the refresh frequency for the widget
   const refresh = React.useMemo(
@@ -136,7 +136,7 @@ export const Widget = React.memo(() => {
   return (
     <DataWidget.Widget
       classes={classes}
-      Icon={Icon}
+      Icon={showIcon ? Icon : null}
       onClick={onClick}
       onRightClick={onRightClick}
       onMiddleClick={onMiddleClick}

--- a/lib/components/data/stock.jsx
+++ b/lib/components/data/stock.jsx
@@ -32,6 +32,7 @@ export const Widget = React.memo(() => {
     showMarketPercent,
     showColor,
     showOnDisplay,
+    showIcon,
   } = stockWidgetOptions;
 
   // Determine the refresh frequency for the widget
@@ -137,7 +138,7 @@ export const Widget = React.memo(() => {
         key={symbolName}
         classes="stock"
         ref={ref}
-        Icon={stockUp ? Icons.UpArrow : Icons.DownArrow}
+        Icon={showIcon ? (stockUp ? Icons.UpArrow : Icons.DownArrow) : null}
         href={`https://finance.yahoo.com/quote/${symbolName}`}
         onClick={openStock}
         onRightClick={refreshStocks}

--- a/lib/components/data/time.jsx
+++ b/lib/components/data/time.jsx
@@ -20,7 +20,7 @@ export const Widget = React.memo(() => {
   const { displayIndex, settings } = useSimpleBarContext();
   const { widgets, timeWidgetOptions } = settings;
   const { timeWidget } = widgets;
-  const { refreshFrequency, hour12, dayProgress, showSeconds, showOnDisplay } =
+  const { refreshFrequency, hour12, dayProgress, showSeconds, showOnDisplay, showIcon } =
     timeWidgetOptions;
 
   // Determine if the widget should be visible on the current display
@@ -93,7 +93,7 @@ export const Widget = React.memo(() => {
   };
 
   return (
-    <DataWidget.Widget classes="time" Icon={TimeIcon} disableSlider>
+    <DataWidget.Widget classes="time" Icon={showIcon ? TimeIcon : null} disableSlider>
       {time}
       {dayProgress && (
         <div

--- a/lib/components/data/viscosity-vpn.jsx
+++ b/lib/components/data/viscosity-vpn.jsx
@@ -26,6 +26,7 @@ export const Widget = React.memo(() => {
     vpnConnectionName,
     vpnShowConnectionName,
     showOnDisplay,
+    showIcon,
   } = vpnWidgetOptions;
 
   // Determine the refresh frequency for the widget
@@ -102,7 +103,7 @@ export const Widget = React.memo(() => {
   };
 
   return (
-    <DataWidget.Widget classes={classes} Icon={Icon} onClick={clicked}>
+    <DataWidget.Widget classes={classes} Icon={showIcon ? Icon : null} onClick={clicked}>
       {vpnShowConnectionName ? vpnConnectionName : status}
     </DataWidget.Widget>
   );

--- a/lib/components/data/weather.jsx
+++ b/lib/components/data/weather.jsx
@@ -27,6 +27,7 @@ export const Widget = React.memo(() => {
     hideLocation,
     hideGradient,
     showOnDisplay,
+    showIcon,
   } = weatherWidgetOptions;
 
   const refresh = React.useMemo(
@@ -145,7 +146,7 @@ export const Widget = React.memo(() => {
   return (
     <DataWidget.Widget
       classes={classes}
-      Icon={Icon}
+      Icon={showIcon ? Icon : null}
       href={`https://wttr.in/${state.location}${wttrUnitParam}`}
       onClick={(e) => openWeather(e, pushMissive)}
       onRightClick={onRightClick}

--- a/lib/components/data/wifi.jsx
+++ b/lib/components/data/wifi.jsx
@@ -28,6 +28,7 @@ export const Widget = React.memo(() => {
     networkDevice,
     hideNetworkName,
     showOnDisplay,
+    showIcon,
   } = networkWidgetOptions;
   const visible =
     Utils.isVisibleOnDisplay(displayIndex, showOnDisplay) && wifiWidget;
@@ -99,7 +100,7 @@ export const Widget = React.memo(() => {
   return (
     <DataWidget.Widget
       classes={classes}
-      Icon={Icon}
+      Icon={showIcon ? Icon : null}
       onClick={toggleWifiOnClick ? onClick : undefined}
       onRightClick={openWifiPreferences}
     >

--- a/lib/components/data/youtube-music.jsx
+++ b/lib/components/data/youtube-music.jsx
@@ -26,6 +26,7 @@ export const Widget = React.memo(() => {
       showSpecter,
       showOnDisplay,
       youtubeMusicPort,
+      showIcon,
     },
   } = settings;
 
@@ -167,7 +168,7 @@ export const Widget = React.memo(() => {
   return (
     <DataWidget.Widget
       classes={classes}
-      Icon={Icon}
+      Icon={showIcon ? Icon : null}
       onClick={onClick}
       onRightClick={onRightClick}
       onMiddleClick={onMiddleClick}

--- a/lib/components/data/zoom.jsx
+++ b/lib/components/data/zoom.jsx
@@ -22,7 +22,7 @@ export const Widget = React.memo(() => {
   const { displayIndex, settings } = useSimpleBarContext();
   const { widgets, zoomWidgetOptions } = settings;
   const { zoomWidget } = widgets;
-  const { refreshFrequency, showVideo, showMic, showOnDisplay } =
+  const { refreshFrequency, showVideo, showMic, showOnDisplay, showIcon } =
     zoomWidgetOptions;
 
   // Determine the refresh frequency for the widget
@@ -87,12 +87,12 @@ export const Widget = React.memo(() => {
 
   return (
     <DataWidget.Widget classes="zoom">
-      {showVideo && (
+      {showIcon && showVideo && (
         <SuspenseIcon>
           <VideoIcon className={`zoom__icon zoom__icon--${video}`} />
         </SuspenseIcon>
       )}
-      {showMic && (
+      {showIcon && showMic && (
         <SuspenseIcon>
           <MicIcon className={`zoom__icon zoom__icon--${mic}`} />
         </SuspenseIcon>

--- a/lib/schemas/config.json
+++ b/lib/schemas/config.json
@@ -422,6 +422,10 @@
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
         },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
+        },
         "unit": {
           "type": "string",
           "enum": ["C", "F"],
@@ -453,6 +457,10 @@
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
         },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
+        },
         "displayAsGraph": {
           "type": "boolean",
           "description": "Instead of show current network information, the widget will display a graphic showing the latest 60 seconds (it can change depending of the refresh frequency of the widget) of network activity. All drawn points are relative to the highest value"
@@ -470,6 +478,10 @@
         "showOnDisplay": {
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
+        },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
         },
         "displayAsGraph": {
           "type": "boolean",
@@ -494,6 +506,10 @@
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
         },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
+        },
         "displayAsGraph": {
           "type": "boolean",
           "description": "Instead of show current CPU information, the widget will display a graphic showing the latest 100 seconds (it can change depending of the refresh frequency of the widget) of CPU activity. All drawn points are relative to the highest value"
@@ -513,6 +529,10 @@
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
         },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
+        },
         "memoryMonitorApp": {
           "type": "string",
           "enum": ["Activity Monitor", "Top", "None"],
@@ -531,6 +551,10 @@
         "showOnDisplay": {
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
+        },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
         },
         "toggleCaffeinateOnClick": {
           "type": "boolean",
@@ -553,6 +577,10 @@
         "showOnDisplay": {
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
+        },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
         },
         "networkDevice": {
           "type": "string",
@@ -584,6 +612,10 @@
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
         },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
+        },
         "vpnConnectionName": {
           "type": "string",
           "description": "The name of the connection you want to display"
@@ -606,6 +638,10 @@
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
         },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
+        },
         "showVideo": {
           "type": "boolean",
           "description": "Displays your current call video status"
@@ -627,6 +663,10 @@
         "showOnDisplay": {
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
+        },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
         }
       }
     },
@@ -641,6 +681,10 @@
         "showOnDisplay": {
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
+        },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
         }
       }
     },
@@ -655,6 +699,10 @@
         "showOnDisplay": {
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
+        },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
         },
         "shortDateFormat": {
           "type": "boolean",
@@ -682,6 +730,10 @@
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
         },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
+        },
         "hour12": {
           "type": "boolean",
           "description": "Display time in 12h format"
@@ -707,6 +759,10 @@
         "showOnDisplay": {
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
+        },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
         }
       }
     },
@@ -721,6 +777,10 @@
         "showOnDisplay": {
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
+        },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
         },
         "denomination": {
           "type": "string",
@@ -748,6 +808,10 @@
         "showOnDisplay": {
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
+        },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
         },
         "yahooFinanceApiKey": {
           "type": "string",
@@ -795,6 +859,10 @@
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
         },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
+        },
         "showSpecter": {
           "type": "boolean",
           "description": "Show the specter animation when a song is playing"
@@ -812,6 +880,10 @@
         "showOnDisplay": {
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
+        },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
         },
         "showSpecter": {
           "type": "boolean",
@@ -835,6 +907,10 @@
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
         },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
+        },
         "showSpecter": {
           "type": "boolean",
           "description": "Show the specter animation when a song is playing"
@@ -852,6 +928,10 @@
         "showOnDisplay": {
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
+        },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
         },
         "showSpecter": {
           "type": "boolean",
@@ -880,6 +960,10 @@
         "showOnDisplay": {
           "type": "string",
           "description": "The displays on which the process will be displayed. Add a list of indexes (for example: \"1,2\"). Leave blank to display the widget on every spaces"
+        },
+        "showIcon": {
+          "type": "boolean",
+          "description": "Show or hide the widget icon"
         },
         "showSpecter": {
           "type": "boolean",

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -372,6 +372,7 @@ export const data = {
       "Doing so, you need to allow Übersicht access to your location: a popup should appear on first use.",
     ],
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
   unit: {
     title: "Temperature unit",
     label: "",
@@ -395,6 +396,7 @@ export const data = {
       "The default value is set to 2000 ms (2 seconds).",
     ],
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
 
   cpuWidgetOptions: {
     label: "CPU usage",
@@ -404,6 +406,7 @@ export const data = {
       "The default value is set to 2000 ms (2 seconds).",
     ],
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
 
   gpuWidgetOptions: {
     label: "GPU usage",
@@ -413,6 +416,7 @@ export const data = {
       "The default value is set to 2000 ms (2 seconds).",
     ],
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
 
   gpuMacmonBinaryPath: {
     label: "Path to macmon binary",
@@ -429,6 +433,7 @@ export const data = {
       "The default value is set to 4000 ms (4 seconds).",
     ],
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
 
   displayAsGraph: {
     label: "Display as graph",
@@ -462,6 +467,7 @@ export const data = {
       "-t 60 — Specifies the timeout value in seconds for which the command is valid.",
     ],
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
   toggleCaffeinateOnClick: {
     label: "Toggle caffeinate on click",
     type: "checkbox",
@@ -482,6 +488,7 @@ export const data = {
       "Additionally, you can choose to hide the network name for privacy.",
     ],
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
   networkDevice: {
     label: "Network device source name",
     type: "text",
@@ -496,6 +503,7 @@ export const data = {
     documentation: "/viscosity-vpn/",
     infos: ["Here you can set your Viscosity vpn connection name."],
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
   vpnConnectionName: {
     label: "Viscosity connection name",
     type: "text",
@@ -511,6 +519,7 @@ export const data = {
     label: "Zoom status",
     documentation: "/zoom/",
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
   showVideo: { label: "Show video status", type: "checkbox" },
   showMic: { label: "Show mic status", type: "checkbox" },
 
@@ -518,19 +527,23 @@ export const data = {
     label: "Sound",
     documentation: "/sound/",
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
   micWidgetOptions: {
     label: "Mic",
     documentation: "/microphone/",
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
   keyboardWidgetOptions: {
     label: "Keyboard",
     documentation: "/keyboard/",
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
 
   timeWidgetOptions: {
     label: "Time",
     documentation: "/time/",
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
   hour12: { label: "12h time format", type: "checkbox" },
   dayProgress: { label: "Day progress", type: "checkbox" },
   showSeconds: { label: "Show seconds", type: "checkbox" },
@@ -539,6 +552,7 @@ export const data = {
     label: "Date",
     documentation: "/date/",
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
   shortDateFormat: { label: "Short format", type: "checkbox" },
   locale: { label: "Locale", type: "text", placeholder: "example: en-UK" },
   calendarApp: {
@@ -551,14 +565,17 @@ export const data = {
   youtubeMusicWidgetOptions: {
     label: "YouTube Music",
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
   spotifyWidgetOptions: {
     label: "Spotify",
     documentation: "/spotify/",
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
   cryptoWidgetOptions: {
     label: "Crypto",
     documentation: "/crypto/",
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
   stockWidgetOptions: {
     label: "Stock",
     documentation: "/stocks/",
@@ -568,16 +585,19 @@ export const data = {
       "You can register for free and use the Basic tier (100 requests/day).",
     ],
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
 
   musicWidgetOptions: {
     label: "Music/iTunes",
     documentation: "/music-itunes/",
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
 
   mpdWidgetOptions: {
     label: "MPD via mpc",
     documentation: "/mpd-state-via-mpc/",
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
   mpdBinaryPath: {
     label: "Path to mpc binary",
     type: "text",
@@ -605,6 +625,7 @@ export const data = {
     label: "Browser",
     documentation: "/browser-track/",
   },
+  showIcon: { label: "Show icon", type: "checkbox" },
   showSpecter: { label: "Show animated specter", type: "checkbox" },
   youtubeMusicPort: { label: "Port", type: "text", placeholder: "26538" },
 
@@ -765,6 +786,7 @@ export const defaultSettings = {
   weatherWidgetOptions: {
     refreshFrequency: 1000 * 60 * 30,
     showOnDisplay: "",
+    showIcon: true,
     unit: "C",
     hideLocation: false,
     hideGradient: false,
@@ -773,34 +795,40 @@ export const defaultSettings = {
   netstatsWidgetOptions: {
     refreshFrequency: 2000,
     showOnDisplay: "",
+    showIcon: true,
     displayAsGraph: false,
   },
   cpuWidgetOptions: {
     refreshFrequency: 2000,
     showOnDisplay: "",
+    showIcon: true,
     displayAsGraph: false,
     cpuMonitorApp: "Activity Monitor",
   },
   gpuWidgetOptions: {
     refreshFrequency: 3000,
     showOnDisplay: "",
+    showIcon: true,
     displayAsGraph: false,
     gpuMacmonBinaryPath: "/opt/homebrew/bin/macmon",
   },
   memoryWidgetOptions: {
     refreshFrequency: 4000,
     showOnDisplay: "",
+    showIcon: true,
     memoryMonitorApp: "Activity Monitor",
   },
   batteryWidgetOptions: {
     refreshFrequency: 10000,
     showOnDisplay: "",
+    showIcon: true,
     toggleCaffeinateOnClick: true,
     caffeinateOption: "",
   },
   networkWidgetOptions: {
     refreshFrequency: 20000,
     showOnDisplay: "",
+    showIcon: true,
     networkDevice: "en0",
     hideWifiIfDisabled: false,
     toggleWifiOnClick: false,
@@ -809,26 +837,31 @@ export const defaultSettings = {
   vpnWidgetOptions: {
     refreshFrequency: 8000,
     showOnDisplay: "",
+    showIcon: true,
     vpnConnectionName: "",
     vpnShowConnectionName: false,
   },
   zoomWidgetOptions: {
     refreshFrequency: 5000,
     showOnDisplay: "",
+    showIcon: true,
     showVideo: true,
     showMic: true,
   },
   soundWidgetOptions: {
     refreshFrequency: 20000,
     showOnDisplay: "",
+    showIcon: true,
   },
   micWidgetOptions: {
     refreshFrequency: 20000,
     showOnDisplay: "",
+    showIcon: true,
   },
   dateWidgetOptions: {
     refreshFrequency: 30000,
     showOnDisplay: "",
+    showIcon: true,
     shortDateFormat: true,
     locale: "en-UK",
     calendarApp: "",
@@ -836,6 +869,7 @@ export const defaultSettings = {
   timeWidgetOptions: {
     refreshFrequency: 1000,
     showOnDisplay: "",
+    showIcon: true,
     hour12: false,
     dayProgress: true,
     showSeconds: false,
@@ -843,10 +877,12 @@ export const defaultSettings = {
   keyboardWidgetOptions: {
     refreshFrequency: 20000,
     showOnDisplay: "",
+    showIcon: true,
   },
   cryptoWidgetOptions: {
     refreshFrequency: 5 * 60 * 1000,
     showOnDisplay: "",
+    showIcon: true,
     denomination: "usd",
     identifiers: "bitcoin,ethereum,celo",
     precision: 5,
@@ -854,6 +890,7 @@ export const defaultSettings = {
   stockWidgetOptions: {
     refreshFrequency: 15 * 60 * 1000,
     showOnDisplay: "",
+    showIcon: true,
     yahooFinanceApiKey: "YOUR_API_KEY",
     symbols: "AAPL,TSLA",
     showSymbol: true,
@@ -866,22 +903,26 @@ export const defaultSettings = {
   spotifyWidgetOptions: {
     refreshFrequency: 10000,
     showOnDisplay: "",
+    showIcon: true,
     showSpecter: true,
   },
   youtubeMusicWidgetOptions: {
     refreshFrequency: 10000,
     showOnDisplay: "",
+    showIcon: true,
     showSpecter: true,
     youtubeMusicPort: 26538,
   },
   musicWidgetOptions: {
     refreshFrequency: 10000,
     showOnDisplay: "",
+    showIcon: true,
     showSpecter: true,
   },
   mpdWidgetOptions: {
     refreshFrequency: 10000,
     showOnDisplay: "",
+    showIcon: true,
     showSpecter: true,
     mpdBinaryPath: "/opt/homebrew/bin/mpc",
     mpdPort: "6600",
@@ -891,6 +932,7 @@ export const defaultSettings = {
   browserTrackWidgetOptions: {
     refreshFrequency: 10000,
     showOnDisplay: "",
+    showIcon: true,
     showSpecter: true,
   },
   userWidgets: {


### PR DESCRIPTION
# Description

This PR adds a new setting for each widget to optionally disable the icon (default on) to save some width in the bar if wanted.

<img width="632" alt="image" src="https://github.com/user-attachments/assets/1e79e59a-b27c-4071-817d-32035103058c" />

<img width="643" alt="image" src="https://github.com/user-attachments/assets/7f3e836b-a2c7-4005-bbf2-7ee3034e0397" />

<img width="428" alt="image" src="https://github.com/user-attachments/assets/b71ab609-dca8-48f4-b204-6c6fc06c33dc" />


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

I enabled multiple widgets and disabled the icon in the settings.

**Test Configuration**:

- OS version 15.5
- yabai version yabai-v7.1.15
- Übersicht version lateset

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (make use of JSDoc if necessary)
- [ ] My changes generate no new warnings

# Changes to make to the documentation

- The option for the show icon could be added, but is probably not important
