### PR TITLE
Fix infinite finance API request loop

### DIFF
--- a/lib/components/data/crypto.jsx
+++ b/lib/components/data/crypto.jsx
@@ -42,10 +42,15 @@ export const Widget = React.memo(() => {
 
   const ref = React.useRef();
   const denominatorToken = getDenominatorToken(denomination);
-  const cleanedUpIdentifiers = identifiers.replace(/ /g, "");
-  const enumeratedIdentifiers = cleanedUpIdentifiers
-    .replace(/ /g, "")
-    .split(",");
+
+  // Memoize cleanedUpIdentifiers to prevent recreation on every render
+  const cleanedUpIdentifiers = React.useMemo(() => identifiers.replace(/ /g, ""), [identifiers]);
+
+  // Memoize enumeratedIdentifiers to prevent recreation on every render
+  const enumeratedIdentifiers = React.useMemo(() =>
+    cleanedUpIdentifiers.replace(/ /g, "").split(","),
+    [cleanedUpIdentifiers]
+  );
 
   const [state, setState] = React.useState();
   const [loading, setLoading] = React.useState(visible);

--- a/lib/components/data/stock.jsx
+++ b/lib/components/data/stock.jsx
@@ -46,8 +46,15 @@ export const Widget = React.memo(() => {
     Utils.isVisibleOnDisplay(displayIndex, showOnDisplay) && stockWidget;
 
   const ref = React.useRef();
-  const cleanedUpSymbols = symbols.replace(/ /g, "");
-  const enumeratedSymbols = cleanedUpSymbols.replace(/ /g, "").split(",");
+
+  // Memoize cleanedUpSymbols to prevent recreation on every render
+  const cleanedUpSymbols = React.useMemo(() => symbols.replace(/ /g, ""), [symbols]);
+
+  // Memoize enumeratedSymbols to prevent recreation on every render
+  const enumeratedSymbols = React.useMemo(() =>
+    cleanedUpSymbols.replace(/ /g, "").split(","),
+    [cleanedUpSymbols]
+  );
 
   const [state, setState] = React.useState();
   const [loading, setLoading] = React.useState(visible);


### PR DESCRIPTION
# Description

The "Stock" and "Crypto" widgets don't appear, logs show 429 errors after immediately hitting the https://financeapi.net API quota limit of 100 calls/day.

<img width="811" alt="quota limit" src="https://github.com/user-attachments/assets/9e2107d0-e45f-49e5-841e-d97ec5f4cfd3" />

Fixes # (issue not created)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Ran & verified Stock widget appears, API calls in normal expected range

<img width="828" alt="normal range" src="https://github.com/user-attachments/assets/8a0d013d-c332-44a4-b08d-0bea81a8d40e" />

**Test Configuration**:

- OS version [Sequoia 15.5]
- aerospace version [0.18.5-Beta]
- Übersicht version [Version 1.6 (82)]

# Checklist:

- [X] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas (make use of JSDoc if necessary)
- [X] My changes generate no new warnings
