### PR TITLE
* Added displayForFocusedSpace settings, when set the single bar will…

### DIFF
--- a/lib/components/yabai/process.jsx
+++ b/lib/components/yabai/process.jsx
@@ -19,7 +19,7 @@ const Component = React.memo(() => {
   const { process, spacesDisplay, widgets } = settings;
   const { processWidget } = widgets;
   const { exclusionsAsRegex } = spacesDisplay;
-  const { centered, showCurrentSpaceMode, displaySkhdMode, showOnDisplay } =
+  const { displayForFocusedSpace, centered, showCurrentSpaceMode, displaySkhdMode, showOnDisplay } =
     process;
 
   // Determine if the process widget should be visible
@@ -43,10 +43,11 @@ const Component = React.memo(() => {
   const currentSpace = spaces.find((space) => {
     const {
       "is-visible": isVisible,
+      "has-focus" : hasFocus,
       visible: __legacyIsVisible,
       display,
     } = space;
-    return (isVisible ?? __legacyIsVisible) && display === displayIndex;
+    return (isVisible ?? __legacyIsVisible) && (displayForFocusedSpace ? hasFocus : display === displayIndex);
   });
 
   // Get sticky and non-sticky windows using a utility function

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -196,6 +196,12 @@ export const data = {
     label: "Process",
     documentation: "/process-settings/",
   },
+  displayForFocusedSpace: {
+    label:
+      "<em>yabai</em> Display for focused space instead of current display space (usefull when you have simple-bar on one display in multi-monitor setup)",
+    type: "checkbox",
+    fullWidth: true,
+  },
   displayOnlyCurrent: {
     label:
       "<em>yabai</em> <em>AeroSpace</em> Display only current process name",
@@ -747,6 +753,7 @@ export const defaultSettings = {
   },
   process: {
     showOnDisplay: "",
+    displayForFocusedSpace: false,
     displayOnlyCurrent: false,
     centered: false,
     showCurrentSpaceMode: false,


### PR DESCRIPTION
# Description

Added displayForFocusedSpace setting to Process Widnget. When set the single bar will show processes for the current focused monitor, even if there is no bar on focused monitor, usefull when you have multi-monitor setup but only want one simple bar on one of them.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Manual testing, worked for me. Shouldn't break existing installations.

**Test Configuration**:

- OS version: Sequoia 15.6.1
- yabai version yabai-v7.1.16
- Übersicht version 1.6 (82)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas (make use of JSDoc if necessary)
- [X] My changes generate no new warnings

# Changes to make to the documentation

Please list any changes to the documentation that are required to reflect your changes.
New setting option should be add to doc, the title could be just copied it's self explanatory.