### PR TITLE
Added thresholds for cpu, memory, network stats widgets; added sett…

### DIFF
--- a/lib/components/data/cpu.jsx
+++ b/lib/components/data/cpu.jsx
@@ -29,6 +29,7 @@ export const Widget = React.memo(() => {
     displayAsGraph,
     cpuMonitorApp,
     showIcon,
+    cpuUsageThreshold,
   } = cpuWidgetOptions;
 
   // Determine if the widget should be visible based on display settings
@@ -64,7 +65,7 @@ export const Widget = React.memo(() => {
       const usage = await Uebersicht.run(
         `top -l 1 | grep -E "^CPU" | grep -Eo '[^[:space:]]+%' | head -1 | sed s/%//`,
       );
-      const formattedUsage = { usage: parseInt(usage, 10).toFixed(0) };
+      const formattedUsage = { usage: parseInt(usage, 10) };
       setState(formattedUsage);
       if (displayAsGraph) {
         Utils.addToGraphHistory(formattedUsage, setGraph, GRAPH_LENGTH);
@@ -84,6 +85,10 @@ export const Widget = React.memo(() => {
   if (!state) return null;
 
   const { usage } = state;
+  const threshold = Number(cpuUsageThreshold) || 0;
+  const usageValue = Number(usage) || 0;
+
+  if (threshold > 0 && usageValue < threshold) return null;
 
   // Handle click event to open CPU monitor app
   const onClick =

--- a/lib/components/data/keyboard.jsx
+++ b/lib/components/data/keyboard.jsx
@@ -21,7 +21,12 @@ export const Widget = React.memo(() => {
   const { displayIndex, settings } = useSimpleBarContext();
   const { widgets, keyboardWidgetOptions } = settings;
   const { keyboardWidget } = widgets;
-  const { refreshFrequency, showOnDisplay, showIcon } = keyboardWidgetOptions;
+  const {
+    refreshFrequency,
+    showOnDisplay,
+    showIcon,
+    keyboardMaxLength,
+  } = keyboardWidgetOptions;
 
   // Determine the refresh frequency for the widget
   const refresh = React.useMemo(
@@ -86,14 +91,18 @@ export const Widget = React.memo(() => {
   if (!state) return null;
   const { keyboard } = state;
 
-  if (!keyboard?.length) return null;
+  const maxLength = Number(keyboardMaxLength) || 0;
+  const displayKeyboard =
+    maxLength > 0 ? keyboard.slice(0, maxLength) : keyboard;
+
+  if (!displayKeyboard?.length) return null;
 
   return (
     <DataWidget.Widget
       classes="keyboard"
       Icon={showIcon ? Icons.Keyboard : null}
     >
-      {keyboard}
+      {displayKeyboard}
     </DataWidget.Widget>
   );
 });

--- a/lib/components/data/memory.jsx
+++ b/lib/components/data/memory.jsx
@@ -20,8 +20,13 @@ export const Widget = () => {
   const { displayIndex, settings } = useSimpleBarContext();
   const { widgets, memoryWidgetOptions } = settings;
   const { memoryWidget } = widgets;
-  const { refreshFrequency, showOnDisplay, memoryMonitorApp, showIcon } =
-    memoryWidgetOptions;
+  const {
+    refreshFrequency,
+    showOnDisplay,
+    memoryMonitorApp,
+    showIcon,
+    memoryUsageThreshold,
+  } = memoryWidgetOptions;
 
   // Determine the refresh frequency for the widget
   const refresh = React.useMemo(
@@ -67,6 +72,9 @@ export const Widget = () => {
 
   const { free } = state;
   const used = 100 - free;
+  const threshold = Number(memoryUsageThreshold) || 0;
+
+  if (threshold > 0 && used < threshold) return null;
 
   // Handle click event to open memory usage app
   const onClick =

--- a/lib/components/data/netstats.jsx
+++ b/lib/components/data/netstats.jsx
@@ -24,8 +24,13 @@ export const Widget = React.memo(() => {
   const { displayIndex, settings } = useSimpleBarContext();
   const { widgets, netstatsWidgetOptions } = settings;
   const { netstatsWidget } = widgets;
-  const { refreshFrequency, showOnDisplay, displayAsGraph, showIcon } =
-    netstatsWidgetOptions;
+  const {
+    refreshFrequency,
+    showOnDisplay,
+    displayAsGraph,
+    showIcon,
+    netstatsThreshold,
+  } = netstatsWidgetOptions;
 
   const isDisabled = React.useRef(false);
 
@@ -101,6 +106,16 @@ export const Widget = React.memo(() => {
   const { download, upload } = state;
 
   if (download === undefined || upload === undefined) {
+    return null;
+  }
+
+  const threshold = (Number(netstatsThreshold) || 0) * 1024;
+  const isBelowThreshold =
+    threshold > 0 &&
+    Math.abs(download) < threshold &&
+    Math.abs(upload) < threshold;
+
+  if (isBelowThreshold) {
     return null;
   }
 

--- a/lib/schemas/config.json
+++ b/lib/schemas/config.json
@@ -502,6 +502,10 @@
         "displayAsGraph": {
           "type": "boolean",
           "description": "Instead of show current network information, the widget will display a graphic showing the latest 60 seconds (it can change depending of the refresh frequency of the widget) of network activity. All drawn points are relative to the highest value"
+        },
+        "netstatsThreshold": {
+          "type": "number",
+          "description": "Hide the widget when download and upload are below this value in kb/s (0 to always show)"
         }
       }
     },
@@ -524,6 +528,10 @@
         "displayAsGraph": {
           "type": "boolean",
           "description": "Instead of show current CPU information, the widget will display a graphic showing the latest 100 seconds (it can change depending of the refresh frequency of the widget) of CPU activity. All drawn points are relative to the highest value"
+        },
+        "cpuUsageThreshold": {
+          "type": "number",
+          "description": "Hide the widget when CPU usage is below this percentage (0 to always show)"
         },
         "cpuMonitorApp": {
           "type": "string",
@@ -570,6 +578,10 @@
         "showIcon": {
           "type": "boolean",
           "description": "Show or hide the widget icon"
+        },
+        "memoryUsageThreshold": {
+          "type": "number",
+          "description": "Hide the widget when used memory is below this percentage (0 to always show)"
         },
         "memoryMonitorApp": {
           "type": "string",
@@ -701,6 +713,10 @@
         "showIcon": {
           "type": "boolean",
           "description": "Show or hide the widget icon"
+        },
+        "keyboardMaxLength": {
+          "type": "number",
+          "description": "Maximum number of characters to display for the keyboard layout (0 to show full name)"
         }
       }
     },

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -424,6 +424,11 @@ export const data = {
       "The default value is set to 2000 ms (2 seconds).",
     ],
   },
+  netstatsThreshold: {
+    label: "Hide below (kb/s)",
+    type: "number",
+    placeholder: "0 to always show",
+  },
 
   cpuWidgetOptions: {
     label: "CPU usage",
@@ -432,6 +437,11 @@ export const data = {
       "Here you can set the refresh frequency of the widget.",
       "The default value is set to 2000 ms (2 seconds).",
     ],
+  },
+  cpuUsageThreshold: {
+    label: "Hide below (%)",
+    type: "number",
+    placeholder: "0 to always show",
   },
 
   gpuWidgetOptions: {
@@ -457,6 +467,11 @@ export const data = {
       "Here you can set the refresh frequency of the widget.",
       "The default value is set to 4000 ms (4 seconds).",
     ],
+  },
+  memoryUsageThreshold: {
+    label: "Hide below (%)",
+    type: "number",
+    placeholder: "0 to always show",
   },
 
   displayAsGraph: {
@@ -560,6 +575,11 @@ export const data = {
   keyboardWidgetOptions: {
     label: "Keyboard",
     documentation: "/keyboard/",
+  },
+  keyboardMaxLength: {
+    label: "Characters to display",
+    type: "number",
+    placeholder: "0 to show full name",
   },
 
   timeWidgetOptions: {
@@ -828,12 +848,14 @@ export const defaultSettings = {
     showOnDisplay: "",
     showIcon: true,
     displayAsGraph: false,
+    netstatsThreshold: 0,
   },
   cpuWidgetOptions: {
     refreshFrequency: 2000,
     showOnDisplay: "",
     showIcon: true,
     displayAsGraph: false,
+    cpuUsageThreshold: 0,
     cpuMonitorApp: "Activity Monitor",
   },
   gpuWidgetOptions: {
@@ -847,6 +869,7 @@ export const defaultSettings = {
     refreshFrequency: 4000,
     showOnDisplay: "",
     showIcon: true,
+    memoryUsageThreshold: 0,
     memoryMonitorApp: "Activity Monitor",
   },
   batteryWidgetOptions: {
@@ -908,6 +931,7 @@ export const defaultSettings = {
     refreshFrequency: 20000,
     showOnDisplay: "",
     showIcon: true,
+    keyboardMaxLength: 0,
   },
   cryptoWidgetOptions: {
     refreshFrequency: 5 * 60 * 1000,


### PR DESCRIPTION
Hey!
Not sure if it's good to have in mainstream, but I do like living with those changes :)

# Description
Added thresholds for cpu, memory, network stats widgets also added setinngs to limit keyboard layout to N chars.

For the thresholds, I found myself to like having all those data in the statusbar, but it eat too much space, while being valuable to me only if system actually goes heavy on those. I.e. I do not care about cpu if it's mostly idle and about ram if there is plenty. So setting a threshold is a nice compromise to have all the data but only if something goes wrong.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?
Tested all manually

