### PR TITLE
feat: add next meeting widget

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -30,6 +30,7 @@ import * as Stock from "./lib/components/data/stock.jsx";
 import * as Music from "./lib/components/data/music.jsx";
 import * as Mpd from "./lib/components/data/mpd.jsx";
 import * as BrowserTrack from "./lib/components/data/browser-track.jsx";
+import * as NextMeeting from "./lib/components/data/next-meeting.jsx";
 import * as Specter from "./lib/components/data/specter.jsx";
 import * as Graph from "./lib/components/data/graph.jsx";
 import * as DataWidgetLoader from "./lib/components/data/data-widget-loader.jsx";
@@ -128,6 +129,7 @@ Utils.injectStyles("simple-bar-index-styles", [
   Music.styles,
   Mpd.styles,
   BrowserTrack.styles,
+  NextMeeting.styles,
   Specter.styles,
   Graph.styles,
   DataWidgetLoader.styles,
@@ -234,6 +236,7 @@ function render({ output, error }) {
           <Gpu.Widget />
           <Memory.Widget />
           <Battery.Widget />
+          <NextMeeting.Widget />
           <Mic.Widget />
           <Sound.Widget />
           <ViscosityVPN.Widget />

--- a/lib/components/data/next-meeting.jsx
+++ b/lib/components/data/next-meeting.jsx
@@ -1,0 +1,303 @@
+/**
+ * Next Meeting Widget
+ *
+ * Displays the next upcoming calendar event with time until start and optional join button.
+ * Uses icalBuddy for fast calendar access with proper recurring event support.
+ *
+ * Requirements:
+ * - macOS with Calendar.app or compatible calendar
+ * - icalBuddy installed (brew install ical-buddy)
+ * - Calendar access permissions granted
+ *
+ * @module next-meeting
+ */
+import * as Uebersicht from "uebersicht";
+import * as DataWidget from "./data-widget.jsx";
+import * as DataWidgetLoader from "./data-widget-loader.jsx";
+import * as Icons from "../icons/icons.jsx";
+import useWidgetRefresh from "../../hooks/use-widget-refresh";
+import useServerSocket from "../../hooks/use-server-socket";
+import { useSimpleBarContext } from "../simple-bar-context.jsx";
+import * as Utils from "../../utils";
+
+export { nextMeetingStyles as styles } from "../../styles/components/data/next-meeting";
+
+const { React } = Uebersicht;
+
+const DEFAULT_REFRESH_FREQUENCY = 60000; // 1 minute
+
+// Timing thresholds (in minutes)
+const URGENT_THRESHOLD = 5;      // Red pulsing when ≤5 min until meeting
+const UPCOMING_THRESHOLD = 15;   // Yellow when ≤15 min until meeting
+const IN_PROGRESS_CUTOFF = 15;   // Stop showing meeting after 15 min in progress (handled by shell script)
+
+// Uses icalBuddy for fast calendar access (handles recurring events properly)
+// Note: Shell script automatically skips meetings that started > IN_PROGRESS_CUTOFF minutes ago
+const BASE_COMMAND = `./simple-bar/lib/scripts/next-meeting.sh`;
+
+/**
+ * Builds the shell command with optional custom icalBuddy path and look-ahead hours.
+ * @param {string} icalBuddyPath - Optional custom path to icalBuddy binary
+ * @param {number} lookAheadHours - Hours to look ahead for meetings (default: 12)
+ * @returns {string} Complete shell command
+ */
+function buildCommand(icalBuddyPath, lookAheadHours) {
+  const hours = lookAheadHours || 12;
+  if (icalBuddyPath && icalBuddyPath.trim()) {
+    // Escape special shell characters to prevent injection
+    const safePath = icalBuddyPath.replace(/["$`\\]/g, '\\$&');
+    return `${BASE_COMMAND} "${safePath}" ${hours}`;
+  }
+  return `${BASE_COMMAND} "" ${hours}`;
+}
+
+// Patterns to extract meeting URLs from notes
+const MEETING_URL_PATTERNS = [
+  /https?:\/\/[\w-]*\.?zoom\.us\/[^\s<>"]+/gi,
+  /https?:\/\/teams\.microsoft\.com\/l\/meetup-join\/[^\s<>"]+/gi,
+  /https?:\/\/meet\.google\.com\/[^\s<>"]+/gi,
+  /https?:\/\/[\w-]*\.?webex\.com\/[^\s<>"]+/gi,
+];
+
+// SafeLinks pattern (Microsoft Outlook protection wrapper)
+const SAFELINKS_PATTERN = /https?:\/\/[\w.-]*safelinks\.protection\.outlook\.com\/[^\s<>">\]]+/gi;
+
+/**
+ * Decode a URL that may be URL-encoded
+ * @param {string} url - Possibly encoded URL
+ * @returns {string} Decoded URL
+ */
+function decodeUrl(url) {
+  try {
+    return decodeURIComponent(url);
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Extract the real URL from a SafeLink wrapper
+ * @param {string} safeLink - SafeLink URL
+ * @returns {string} Extracted real URL or original
+ */
+function extractFromSafeLink(safeLink) {
+  const urlParam = safeLink.match(/[?&]url=([^&]+)/i);
+  if (urlParam && urlParam[1]) {
+    return decodeUrl(urlParam[1]);
+  }
+  return safeLink;
+}
+
+/**
+ * Extract meeting URL from event URL or notes
+ * @param {string} url - Event URL
+ * @param {string} notes - Event notes/description
+ * @returns {string|null} Meeting URL or null
+ */
+function extractMeetingUrl(url, notes) {
+  // First check direct URL
+  if (url && url.trim() && url !== "missing value") {
+    for (const pattern of MEETING_URL_PATTERNS) {
+      pattern.lastIndex = 0;
+      const match = url.match(pattern);
+      if (match) return match[0];
+    }
+    if (url.startsWith("http")) return url;
+  }
+
+  // Check notes for meeting links
+  if (notes && notes.trim()) {
+    // First try direct meeting URLs
+    for (const pattern of MEETING_URL_PATTERNS) {
+      pattern.lastIndex = 0;
+      const match = notes.match(pattern);
+      if (match) return match[0];
+    }
+
+    // Check for SafeLinks that contain meeting URLs
+    SAFELINKS_PATTERN.lastIndex = 0;
+    const safeLinks = notes.match(SAFELINKS_PATTERN);
+    if (safeLinks) {
+      for (const safeLink of safeLinks) {
+        const realUrl = extractFromSafeLink(safeLink);
+        for (const pattern of MEETING_URL_PATTERNS) {
+          pattern.lastIndex = 0;
+          if (pattern.test(realUrl)) {
+            return realUrl;
+          }
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Format time until meeting
+ * @param {number} minutes - Minutes until meeting
+ * @returns {string} Formatted time string
+ */
+function formatTimeUntil(minutes) {
+  if (minutes < 0) return "now";
+  if (minutes < 1) return "<1m";
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  if (mins === 0) return `${hours}h`;
+  return `${hours}h ${mins}m`;
+}
+
+/**
+ * Parse meeting data from AppleScript output
+ * @param {string} output - Raw command output
+ * @returns {Object|null} Meeting object or null
+ */
+function parseMeetingData(output) {
+  if (!output || !output.trim()) return null;
+
+  const parts = output.trim().split("|");
+  if (parts.length < 5) return null;
+
+  const [title, startTime, url, notes, minutesUntil] = parts;
+  if (!title) return null;
+
+  const meetingUrl = extractMeetingUrl(url, notes);
+
+  return {
+    title: title.trim(),
+    startTime: startTime,
+    url: meetingUrl,
+    minutesUntil: parseInt(minutesUntil, 10) || 0,
+  };
+}
+
+/**
+ * Join button sub-component for meeting URLs.
+ * @component
+ * @param {Object} props - Component props
+ * @param {string} props.url - Meeting URL to open
+ * @returns {JSX.Element} Join button element
+ */
+const JoinButton = React.memo(({ url }) => {
+  /**
+   * Opens the meeting URL when clicked.
+   * @param {React.MouseEvent} e - Click event
+   */
+  const handleJoin = async (e) => {
+    e.stopPropagation();
+    Utils.clickEffect(e);
+    // Escape special shell characters to prevent injection
+    const safeUrl = url.replace(/["$`\\]/g, '\\$&');
+    await Uebersicht.run(`open "${safeUrl}"`);
+  };
+
+  return (
+    <button
+      className="next-meeting__join"
+      onClick={handleJoin}
+      title="Join meeting"
+      aria-label="Join video meeting"
+    >
+      Join
+    </button>
+  );
+});
+
+JoinButton.displayName = "JoinButton";
+
+/**
+ * Next Meeting widget component
+ * Shows the next upcoming meeting with optional join button
+ * @returns {JSX.Element|null} The next meeting widget
+ */
+export const Widget = React.memo(() => {
+  const { displayIndex, settings } = useSimpleBarContext();
+  const { widgets, nextMeetingWidgetOptions, dateWidgetOptions } = settings;
+  const { nextMeetingWidget } = widgets;
+  const { refreshFrequency, showOnDisplay, showJoinButton, showTimeOnly, icalBuddyPath, lookAheadHours } =
+    nextMeetingWidgetOptions;
+
+  // Calculate the refresh frequency for the widget
+  const refresh = React.useMemo(
+    () =>
+      Utils.getRefreshFrequency(refreshFrequency, DEFAULT_REFRESH_FREQUENCY),
+    [refreshFrequency]
+  );
+
+  // Determine if the widget should be visible based on display settings
+  const visible =
+    Utils.isVisibleOnDisplay(displayIndex, showOnDisplay) && nextMeetingWidget;
+
+  const [state, setState] = React.useState(null);
+  const [loading, setLoading] = React.useState(visible);
+
+  /**
+   * Resets the widget state.
+   */
+  const resetWidget = React.useCallback(() => {
+    setState(null);
+    setLoading(false);
+  }, []);
+
+  /**
+   * Fetches next meeting and updates the state.
+   */
+  const getMeeting = React.useCallback(async () => {
+    if (!visible) return;
+    try {
+      const command = buildCommand(icalBuddyPath, lookAheadHours);
+      const output = await Uebersicht.run(command);
+      const meeting = parseMeetingData(output);
+      setState(meeting);
+    } catch (error) {
+      console.error("Error fetching next meeting:", error);
+      setState(null);
+    }
+    setLoading(false);
+  }, [visible, icalBuddyPath, lookAheadHours]);
+
+  // Server socket for real-time updates
+  useServerSocket("next-meeting", visible, getMeeting, resetWidget, setLoading);
+
+  // Refresh the widget at the specified interval
+  useWidgetRefresh(visible, getMeeting, refresh);
+
+  if (loading) return <DataWidgetLoader.Widget className="next-meeting" />;
+  if (!state) return null;
+
+  const { title, minutesUntil, url } = state;
+  const timeDisplay = formatTimeUntil(minutesUntil);
+  const isInProgress = minutesUntil < 0;
+  const isUrgent = minutesUntil <= URGENT_THRESHOLD;      // Red pulsing: ≤5 min or in progress (up to 15 min)
+  const isUpcoming = minutesUntil <= UPCOMING_THRESHOLD;  // Yellow: ≤15 min (but not urgent/in-progress)
+
+  const widgetClasses = Utils.classNames("next-meeting", {
+    "next-meeting--urgent": isUrgent,
+    "next-meeting--upcoming": isUpcoming && !isUrgent,
+  });
+
+  /**
+   * Handle click event to open the calendar application
+   * @param {Event} e - The click event
+   */
+  const openCalendar = async (e) => {
+    Utils.clickEffect(e);
+    const calendarApp = dateWidgetOptions?.calendarApp || "Calendar";
+    await Uebersicht.run(`open -a "${calendarApp}"`);
+  };
+
+  return (
+    <DataWidget.Widget
+      classes={widgetClasses}
+      Icon={Icons.Calendar}
+      onClick={openCalendar}
+    >
+      {!showTimeOnly && <span className="next-meeting__title">{title}</span>}
+      <span className="next-meeting__time">{timeDisplay}</span>
+      {showJoinButton && url && <JoinButton url={url} />}
+    </DataWidget.Widget>
+  );
+});
+
+Widget.displayName = "NextMeeting";

--- a/lib/scripts/next-meeting.sh
+++ b/lib/scripts/next-meeting.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Get next meeting using icalBuddy (much faster than AppleScript, handles recurring events)
+# Usage: next-meeting.sh [icalBuddyPath] [lookAheadHours]
+
+# Configuration
+MAX_IN_PROGRESS_MINUTES=15  # Stop showing "now" after meeting is 15 min in progress
+LOOKAHEAD="${2:-12}"        # How many hours ahead to look for meetings (default: 12)
+MAX_EVENTS=10               # Fetch multiple events to skip stale in-progress ones
+
+# Calculate end time (icalBuddy doesn't support now+Xh syntax)
+END_TIME=$(date -v+${LOOKAHEAD}H "+%Y-%m-%d %H:%M")
+
+# Use custom path if provided, otherwise auto-detect
+CUSTOM_PATH="$1"
+if [ -n "$CUSTOM_PATH" ] && [ -x "$CUSTOM_PATH" ]; then
+  ICALBUDDY="$CUSTOM_PATH"
+else
+  ICALBUDDY=$(which icalBuddy 2>/dev/null)
+  if [ -z "$ICALBUDDY" ]; then
+    if [ -x "/opt/homebrew/bin/icalBuddy" ]; then
+      ICALBUDDY="/opt/homebrew/bin/icalBuddy"
+    elif [ -x "/usr/local/bin/icalBuddy" ]; then
+      ICALBUDDY="/usr/local/bin/icalBuddy"
+    else
+      echo ""
+      exit 0
+    fi
+  fi
+fi
+
+now_epoch=$(date +%s)
+
+# Fetch multiple events - each event bullet starts with <<<E>>>
+# Using a unique prefix that won't appear in notes content
+output=$("$ICALBUDDY" -n -nc -nrd -ea -eed -li "$MAX_EVENTS" \
+  -b "<<<E>>>" -ss "" \
+  -df "%Y-%m-%d" -tf "%H:%M" \
+  -iep "title,datetime,notes" \
+  eventsFrom:"now" to:"$END_TIME" 2>/dev/null)
+
+if [ -z "$output" ]; then
+  echo ""
+  exit 0
+fi
+
+# Write events to temp file for processing
+tmpfile=$(mktemp)
+echo "$output" > "$tmpfile"
+
+# Extract individual events by splitting on <<<E>>> prefix
+event_num=0
+while IFS= read -r line; do
+  if [[ "$line" == "<<<E>>>"* ]]; then
+    # Process previous event if we have one
+    if [ "$event_num" -gt 0 ] && [ -n "$cur_title" ] && [ -n "$cur_start_time" ] && [ -n "$cur_iso_date" ]; then
+      meeting_epoch=$(date -j -f "%Y-%m-%d %H:%M" "$cur_iso_date $cur_start_time" +%s 2>/dev/null)
+      if [ -n "$meeting_epoch" ]; then
+        minutes_until=$(( (meeting_epoch - now_epoch) / 60 ))
+        if [ "$minutes_until" -ge "-$MAX_IN_PROGRESS_MINUTES" ]; then
+          echo "${cur_title}|${cur_iso_date}T${cur_start_time}||${cur_notes}|${minutes_until}"
+          rm -f "$tmpfile"
+          exit 0
+        fi
+      fi
+    fi
+
+    # Start new event
+    event_num=$((event_num + 1))
+    cur_title="${line#<<<E>>>}"
+    cur_title=$(echo "$cur_title" | sed 's/ (Calendar)$//')
+    cur_iso_date=""
+    cur_start_time=""
+    cur_notes=""
+    in_notes=0
+  elif [[ "$line" =~ ^[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}" at "[0-9]{2}:[0-9]{2} ]]; then
+    cur_iso_date=$(echo "$line" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}')
+    cur_start_time=$(echo "$line" | grep -oE 'at [0-9]{2}:[0-9]{2}' | head -1 | sed 's/at //')
+    in_notes=0
+  elif [[ "$line" == *"notes:"* ]]; then
+    in_notes=1
+    cur_notes="$line"
+  elif [ "$in_notes" -eq 1 ]; then
+    cur_notes="${cur_notes} $(echo "$line" | sed 's/|/¦/g')"
+  fi
+done < "$tmpfile"
+
+# Process the last event
+if [ "$event_num" -gt 0 ] && [ -n "$cur_title" ] && [ -n "$cur_start_time" ] && [ -n "$cur_iso_date" ]; then
+  meeting_epoch=$(date -j -f "%Y-%m-%d %H:%M" "$cur_iso_date $cur_start_time" +%s 2>/dev/null)
+  if [ -n "$meeting_epoch" ]; then
+    minutes_until=$(( (meeting_epoch - now_epoch) / 60 ))
+    if [ "$minutes_until" -ge "-$MAX_IN_PROGRESS_MINUTES" ]; then
+      echo "${cur_title}|${cur_iso_date}T${cur_start_time}||${cur_notes}|${minutes_until}"
+      rm -f "$tmpfile"
+      exit 0
+    fi
+  fi
+fi
+
+rm -f "$tmpfile"
+echo ""

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -342,6 +342,7 @@ export const data = {
   musicWidget: { label: "Music/iTunes", type: "checkbox" },
   mpdWidget: { label: "MPD state via mpc", type: "checkbox" },
   browserTrackWidget: { label: "Browser track", type: "checkbox" },
+  nextMeetingWidget: { label: "Next meeting", type: "checkbox" },
 
   showOnDisplay: {
     label: "Show on display n°",
@@ -650,6 +651,30 @@ export const data = {
     label: "Browser",
     documentation: "/browser-track/",
   },
+  nextMeetingWidgetOptions: {
+    label: "Next meeting",
+    infos: [
+      "Shows your next upcoming calendar event with time until start.",
+      "Supports one-click join for Zoom, Teams, Google Meet, and Webex.",
+      "Handles Microsoft SafeLinks (Outlook URL protection) automatically.",
+      "<br/>",
+      "<b>Requires icalBuddy:</b> brew install ical-buddy",
+      "Grant calendar access when prompted.",
+    ],
+  },
+  icalBuddyPath: {
+    label: "Path to icalBuddy binary",
+    type: "text",
+    placeholder: "default: auto-detect (Homebrew)",
+    fullWidth: true,
+  },
+  lookAheadHours: {
+    label: "Look ahead (hours)",
+    type: "number",
+    placeholder: "default: 12",
+  },
+  showJoinButton: { label: "Show join button", type: "checkbox" },
+  showTimeOnly: { label: "Show time only (hide title)", type: "checkbox" },
   showSpecter: { label: "Show animated specter", type: "checkbox" },
   showSpotifyMetadata: { label: "Show Spotify metadata", type: "checkbox" },
   youtubeMusicPort: { label: "Port", type: "text", placeholder: "26538" },
@@ -805,6 +830,7 @@ export const defaultSettings = {
     musicWidget: true,
     mpdWidget: false,
     browserTrackWidget: false,
+    nextMeetingWidget: false,
   },
   githubWidgetOptions: {
     refreshFrequency: 1000 * 60 * 10,
@@ -970,6 +996,14 @@ export const defaultSettings = {
     showOnDisplay: "",
     showIcon: true,
     showSpecter: true,
+  },
+  nextMeetingWidgetOptions: {
+    refreshFrequency: 60000,
+    showOnDisplay: "",
+    showJoinButton: true,
+    showTimeOnly: false,
+    icalBuddyPath: "",
+    lookAheadHours: 12,
   },
   userWidgets: {
     userWidgetsList: {},

--- a/lib/styles/components/data/next-meeting.js
+++ b/lib/styles/components/data/next-meeting.js
@@ -1,0 +1,71 @@
+// Styles for /lib/components/data/next-meeting.jsx component
+export const nextMeetingStyles = /* css */ `
+.next-meeting {
+  background-color: var(--cyan);
+}
+.simple-bar--widgets-background-color-as-foreground .next-meeting {
+  color: var(--cyan);
+  background-color: transparent;
+}
+.simple-bar--no-color-in-data .next-meeting {
+  background-color: var(--minor);
+}
+.next-meeting--upcoming {
+  background-color: var(--yellow) !important;
+}
+.simple-bar--widgets-background-color-as-foreground .next-meeting--upcoming {
+  color: var(--yellow);
+  background-color: transparent !important;
+}
+.next-meeting--urgent {
+  background-color: var(--red) !important;
+  animation: next-meeting-pulse 1.5s ease-in-out infinite;
+}
+.simple-bar--widgets-background-color-as-foreground .next-meeting--urgent {
+  color: var(--red);
+  background-color: transparent !important;
+}
+@keyframes next-meeting-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+.simple-bar--animations-disabled .next-meeting--urgent {
+  animation: none;
+}
+.next-meeting__title {
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-right: 6px;
+}
+.next-meeting__time {
+  font-weight: 600;
+  opacity: 0.9;
+}
+.next-meeting__join {
+  margin-left: 6px;
+  padding: 2px 6px;
+  background-color: rgba(255, 255, 255, 0.2);
+  border: none;
+  border-radius: 3px;
+  color: inherit;
+  font-family: inherit;
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 160ms var(--transition-easing),
+              transform 160ms var(--transition-easing);
+}
+.next-meeting__join:hover {
+  background-color: rgba(255, 255, 255, 0.35);
+  transform: translateY(-1px);
+}
+.next-meeting__join:active {
+  transform: translateY(0);
+}
+.next-meeting__join:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.5);
+}
+`;


### PR DESCRIPTION
Shows the next upcoming calendar event in the bar with time until start and one-click join for video meetings. Uses icalBuddy for fast calendar access with proper recurring event support.

- Color-coded urgency: cyan (normal) → yellow (≤15 min) → red pulsing (≤5 min)
- Join button for Zoom, Teams, Google Meet, and Webex
- Handles Microsoft SafeLinks (Outlook URL protection) automatically
- Configurable look-ahead window and icalBuddy binary path
- Auto-hides when no upcoming meetings
- Requires icalBuddy: brew install ical-buddy
<img width="704" height="85" alt="image" src="https://github.com/user-attachments/assets/1fe5955c-a939-46cc-8ece-9318f82693d2" />


# Description

Main motivation was to hide Dock - and have quick way to see notifications at work (Teams, outlook), also upcoming meeting.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Have been using these changes for ±3months locally.

**Test Configuration**:

- OS version 26.3.1 
- aerospace AeroSpace v0.20.2-Beta 1a8128c53b231bac7e46917468d50b4f15ad30f7
- Übersicht version 1.6 (82)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (make use of JSDoc if necessary)
- [x] My changes generate no new warnings

# Changes to make to the documentation

Please list any changes to the documentation that are required to reflect your changes.
