### PR TITLE
fix: retry AeroSpace connection on startup

### DIFF
--- a/lib/scripts/init-aerospace.sh
+++ b/lib/scripts/init-aerospace.sh
@@ -4,13 +4,23 @@ aerospace_path=$1
 # Get the status of System Integrity Protection (SIP) and store it in the variable SIP
 SIP=$(csrutil status)
 
-# List monitors using the aerospace tool, format the output as JSON, and store it in the variable displays
-# Redirect any error output to /dev/null
-displays=$($aerospace_path list-monitors --json --format "%{monitor-id} %{monitor-name} %{monitor-appkit-nsscreen-screens-id}" 2> /dev/null)
+# Wait for AeroSpace to be ready (up to 30 seconds)
+# On login, Übersicht may start before AeroSpace is fully initialized
+max_retries=15
+retry_count=0
+displays=""
 
-# Check if the previous command failed (exit status 1)
-if [ $? -eq 1 ]; then
-  # Print "aerospaceError" and exit the script with status 0
+while [ $retry_count -lt $max_retries ]; do
+  displays=$($aerospace_path list-monitors --json --format "%{monitor-id} %{monitor-name} %{monitor-appkit-nsscreen-screens-id}" 2> /dev/null)
+  if [ $? -eq 0 ] && [ -n "$displays" ]; then
+    break
+  fi
+  retry_count=$((retry_count + 1))
+  sleep 2
+done
+
+# If AeroSpace is still not ready after retries, report the error
+if [ -z "$displays" ]; then
   echo "aerospaceError"
   exit 0
 fi


### PR DESCRIPTION
## Summary
- On login, Übersicht may start before AeroSpace is fully initialized
- `init-aerospace.sh` now retries the connection every 2 seconds for up to 30 seconds instead of immediately returning `aerospaceError`
- Prevents the bar from staying blank after a reboot

## Test plan
- [ ] Reboot macOS with both Übersicht and AeroSpace as login items
- [ ] Verify simple-bar appears without needing to manually refresh Übersicht
- [ ] Verify normal startup (AeroSpace already running) is not delayed