### PR TITLE
Cyberdream Light and Dark Themes

### DIFF
--- a/lib/styles/themes.js
+++ b/lib/styles/themes.js
@@ -30,6 +30,8 @@ import * as VscodeDarkModern from "./themes/vscode-dark-modern";
 import * as RosePine from "./themes/rose-pine";
 import * as RosePineMoon from "./themes/rose-pine-moon";
 import * as RosePineDawn from "./themes/rose-pine-dawn";
+import * as CyberdreamLight from "./themes/cyberdream-light.js";
+import * as CyberdreamDark from "./themes/cyberdream-dark.js";
 
 // Entire collection of themes available in simple-bar
 export const collection = {
@@ -65,4 +67,6 @@ export const collection = {
   RosePine: RosePine.theme,
   RosePineMoon: RosePineMoon.theme,
   RosePineDawn: RosePineDawn.theme,
+  CyberdreamLight: CyberdreamLight.theme,
+  CyberdreamDark: CyberdreamDark.theme,
 };

--- a/lib/styles/themes/cyberdream-dark.js
+++ b/lib/styles/themes/cyberdream-dark.js
@@ -1,0 +1,32 @@
+export const theme = {
+  name: "Cyberdream Dark",
+  kind: "dark",
+  main: "rgba(22, 24, 26, 0.6)", // Base - with 40% transparency
+  mainAlt: "rgba(30, 33, 36, 0.6)", // Mantle - with 40% transparency
+  minor: "rgba(60, 64, 72, 0.6)", // Crust - with 40% transparency
+  red: "#ff6e5e", // Red
+  green: "#5eff6c", // Neon Green
+  yellow: "#f1ff5e", // Yellow
+  orange: "#ffbd5e", // Orange
+  blue: "#5ea1ff", // Blue
+  magenta: "#ff5ef1", // Magenta
+  cyan: "#5ef1ff", // Cyan
+  black: "#16181a", // Base
+  white: "#ffffff", // Text
+  foreground: "#ffffff", // Text
+  transparentDark: "rgba(0, 0, 0, 0.05)",
+  defaultFont: "JetBrains Mono, Monaco, Menlo, monospace",
+  barHeight: "34px",
+  compactBarHeight: "28px",
+  barRadius: "3px",
+  barBorder: "0px solid transparent",
+  barInnerMargin: "3px",
+  itemRadius: "2px",
+  itemInnerMargin: "3px 7px",
+  itemOuterMargin: "0 0 0 5px",
+  hoverRing: "0 0 0 2px rgba(255, 255, 255, 0.75)",
+  focusRing: "0 0 0 2px rgb(255, 255, 255)",
+  lightShadow: "0 5px 10px rgba(0, 0, 0, 0.24)",
+  transitionEasing: "cubic-bezier(0.4, 0, 0.2, 1)",
+  clickEffect: "rgba(255, 255, 255, 0.3)",
+};

--- a/lib/styles/themes/cyberdream-light.js
+++ b/lib/styles/themes/cyberdream-light.js
@@ -1,0 +1,32 @@
+export const theme = {
+  name: "Cyberdream Light",
+  kind: "light",
+  main: "rgba(255, 255, 255, 0.6)", // Base - with 40% transparency
+  mainAlt: "rgba(234, 234, 234, 0.6)", // Mantle - with 40% transparency
+  minor: "rgba(172, 172, 172, 0.6)", // Crust - with 40% transparency
+  red: "#d11500", // Red
+  green: "#008b0c", // Green
+  yellow: "#997b00", // Bronze
+  orange: "#d17c00", // Orange
+  blue: "#0057d1", // Indigo
+  magenta: "#d100bf", // Magenta
+  cyan: "#008c99", // Aqua
+  black: "#16181a", // Text
+  white: "#ffffff", // Base
+  foreground: "#16181a", // Text
+  transparentDark: "rgba(0, 0, 0, 0.05)",
+  defaultFont: "JetBrains Mono, Monaco, Menlo, monospace",
+  barHeight: "34px",
+  compactBarHeight: "28px",
+  barRadius: "3px",
+  barBorder: "0px solid transparent",
+  barInnerMargin: "3px",
+  itemRadius: "2px",
+  itemInnerMargin: "3px 7px",
+  itemOuterMargin: "0 0 0 5px",
+  hoverRing: "0 0 0 2px rgba(255, 255, 255, 0.75)",
+  focusRing: "0 0 0 2px rgb(255, 255, 255)",
+  lightShadow: "0 5px 10px rgba(0, 0, 0, 0.24)",
+  transitionEasing: "cubic-bezier(0.4, 0, 0.2, 1)",
+  clickEffect: "rgba(255, 255, 255, 0.3)",
+};


### PR DESCRIPTION
# Description

Implementing light and dark theme for simple-bar from scottmckendry's [cyberdream](https://github.com/scottmckendry/cyberdream.nvim). 

> [!NOTE]
> I have added a 40% transparency to the `main`, `mainAlt` and `minor` colors since the theme encourages transparency. Let me know if this goes against your design choices. 
> Alternatively, I can add an opaque and transluscent version for each theme for e.g. `Cyberdream Light (opaque)` and `Cyberdream Light (transluscent)`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested in the local build of simple-bar.

## Cyberdream Light
<img width="2047" height="807" alt="Screenshot 2026-04-22 at 3 52 27 PM" src="https://github.com/user-attachments/assets/3bad0506-dd1a-4616-a6c3-4c7761b38612" />

## Cyberdream Dark
<img width="2039" height="589" alt="Screenshot 2026-04-22 at 3 53 53 PM" src="https://github.com/user-attachments/assets/d2699cff-72d5-4325-9421-e0fc6ba5dcfc" />

**Test Configuration**:

- MacOS Tahoe 26.4.1
- yabai-v7.1.18
- Übersicht version 1.6 (82)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (make use of JSDoc if necessary)
- [x] My changes generate no new warnings

# Changes to make to the documentation

None.