### PR TITLE
Avoid stale AeroSpace refresh results

### DIFF
--- a/lib/components/aerospace-context.jsx
+++ b/lib/components/aerospace-context.jsx
@@ -37,9 +37,13 @@ function AerospaceContextProvider({ children }) {
 
   // State to store aerospace spaces
   const [aerospaceSpaces, setAerospaceSpaces] = React.useState([]);
+  const latestRequestRef = React.useRef(0);
 
   // Fetches and sets the aerospace spaces
   const getSpaces = React.useCallback(async () => {
+    const requestId = latestRequestRef.current + 1;
+    latestRequestRef.current = requestId;
+
     let focusedWindow = {};
     const [focusedSpace] = await Aerospace.getFocusedSpace();
     try {
@@ -68,6 +72,9 @@ function AerospaceContextProvider({ children }) {
         );
       })
     );
+    if (requestId !== latestRequestRef.current) {
+      return;
+    }
     setAerospaceSpaces(spaces.flat());
   }, [displays]);
 


### PR DESCRIPTION
# Description

Rapid AeroSpace workspace switches can trigger overlapping async refreshes. In that case, an older request may resolve after a newer one and temporarily overwrite the latest focused space.

This patch uses a last-request-wins guard in the AeroSpace context and ignores stale refresh results. The tradeoff is that intermediate refreshes are dropped, but the widget should only render the newest workspace state.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Rapidly switched AeroSpace workspaces with simple-bar-server enabled and confirmed that older async refresh results no longer redraw stale focused spaces after a newer workspace update has already been applied.

- [x] Manual rapid workspace switching with AeroSpace + simple-bar-server
- [x] `npm run lint -- lib/components/aerospace-context.jsx`

**Test Configuration**:

- OS version: macOS 26.3.1
- AeroSpace version: 0.19.2-Beta
- Übersicht version: local app install

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (make use of JSDoc if necessary)
- [x] My changes generate no new warnings

# Changes to make to the documentation

None.
